### PR TITLE
Add Dart/Flutter and Elixir SDKs

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,48 @@
+name: Dart SDK
+
+on:
+  push:
+    paths:
+      - "dart/**"
+      - "testdata/**"
+    branches: [main]
+    tags:
+      - "dart/v*"
+  pull_request:
+    paths:
+      - "dart/**"
+      - "testdata/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dart
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
+      - run: dart analyze
+      - run: dart test
+
+  publish:
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/dart/v')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dart
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - run: dart pub get
+      - name: Configure pub credentials
+        env:
+          PUB_CREDENTIALS_JSON: ${{ secrets.PUB_CREDENTIALS_JSON }}
+        run: |
+          mkdir -p "$HOME/.pub-cache"
+          printf '%s' "$PUB_CREDENTIALS_JSON" > "$HOME/.pub-cache/credentials.json"
+      - run: dart pub publish --force

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,0 +1,52 @@
+name: Elixir SDK
+
+on:
+  push:
+    paths:
+      - "elixir/**"
+      - "testdata/**"
+    branches: [main]
+    tags:
+      - "elixir/v*"
+  pull_request:
+    paths:
+      - "elixir/**"
+      - "testdata/**"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: elixir
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.17.3"
+          otp-version: "27.1"
+      - run: mix local.hex --force
+      - run: mix deps.get
+      - run: mix format --check-formatted
+      - run: mix test
+
+  publish:
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/elixir/v')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: elixir
+    permissions:
+      contents: read
+    env:
+      HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.17.3"
+          otp-version: "27.1"
+      - run: mix local.hex --force
+      - run: mix deps.get
+      - run: mix hex.publish --yes

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,17 @@ python/dist/
 python/.venv/
 python/*.egg-info/
 
+# Dart
+dart/.dart_tool/
+dart/build/
+dart/.packages
+
+# Elixir
+elixir/_build/
+elixir/deps/
+elixir/doc/
+elixir/*.ez
+
 # Docs
 /docs
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ All SDKs fetch flag definitions from the Bandeira server, cache flags locally, a
 | **JavaScript/TypeScript** | [`bandeira`](./js) | `npm install bandeira` |
 | **Python** | [`bandeira`](./python) | `pip install bandeira` |
 | **PHP** | [`bandeira/bandeira`](./php) | `composer require bandeira/bandeira` |
+| **Dart/Flutter** | [`bandeira`](./dart) | `dart pub add bandeira` |
+| **Elixir** | [`bandeira`](./elixir) | `{:bandeira, "~> 0.1.0"}` |
 
 ## Quick Start
 
@@ -91,6 +93,40 @@ use Bandeira\Laravel\Facades\Bandeira;
 if (Bandeira::isEnabledForCurrentRequest('my-flag')) {
     // feature is on for current user/request
 }
+```
+
+### Dart / Flutter
+
+```dart
+import 'package:bandeira/bandeira.dart';
+
+Future<void> main() async {
+  final client = await BandeiraClient.create(
+    const BandeiraConfig(
+      url: "http://localhost:8080",
+      token: "your-client-token",
+    ),
+  );
+
+  if (client.isEnabled("my-flag", const BandeiraContext(userId: "user-123"))) {
+    // feature is on
+  }
+
+  client.close();
+}
+```
+
+### Elixir
+
+```elixir
+{:ok, client} = Bandeira.Client.start_link(
+  url: "http://localhost:8080",
+  token: "your-client-token"
+)
+
+if Bandeira.Client.enabled?(client, "my-flag", %Bandeira.Context{user_id: "user-123"}) do
+  # feature is on
+end
 ```
 
 ## License

--- a/dart/README.md
+++ b/dart/README.md
@@ -1,0 +1,72 @@
+# Bandeira Dart/Flutter SDK
+
+Official Dart client SDK for [Bandeira](https://github.com/felipekafuri/bandeira), a self-hosted feature flag service.
+
+## Install
+
+```bash
+dart pub add bandeira
+```
+
+For Flutter apps:
+
+```bash
+flutter pub add bandeira
+```
+
+## Usage
+
+### Option 1: Fail-fast startup with `create()`
+
+```dart
+import 'package:bandeira/bandeira.dart';
+
+Future<void> main() async {
+  final client = await BandeiraClient.create(
+    const BandeiraConfig(
+      url: 'http://localhost:8080',
+      token: 'your-client-token',
+    ),
+  );
+
+  final enabled = client.isEnabled(
+    'my-flag',
+    const BandeiraContext(userId: 'user-123'),
+  );
+
+  if (enabled) {
+    // feature is on
+  }
+
+  client.close();
+}
+```
+
+### Option 2: Construct then `start()`
+
+```dart
+import 'package:bandeira/bandeira.dart';
+
+Future<void> main() async {
+  final client = BandeiraClient(
+    const BandeiraConfig(
+      url: 'http://localhost:8080',
+      token: 'your-client-token',
+    ),
+  );
+
+  await client.start();
+
+  if (client.isEnabled('my-flag')) {
+    // feature is on
+  }
+
+  client.close();
+}
+```
+
+## Notes
+
+- The client polls `/api/v1/flags` in the background and caches flags in memory.
+- `isEnabled` is an in-memory lookup and does not do network I/O.
+- Call `close()` when done to stop polling and release resources.

--- a/dart/analysis_options.yaml
+++ b/dart/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-casts: true

--- a/dart/lib/bandeira.dart
+++ b/dart/lib/bandeira.dart
@@ -1,0 +1,4 @@
+library bandeira;
+
+export 'src/client.dart';
+export 'src/models.dart';

--- a/dart/lib/src/client.dart
+++ b/dart/lib/src/client.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+
+import 'evaluator.dart';
+import 'flag_models.dart';
+import 'http_flags_repository.dart';
+import 'models.dart';
+
+class BandeiraClient {
+  BandeiraClient(
+    BandeiraConfig config, {
+    http.Client? httpClient,
+  })  : _config = _validateConfig(config),
+        _httpClient = httpClient ?? http.Client(),
+        _ownsHttpClient = httpClient == null {
+    _repository = HttpFlagsRepository(
+      url: _config.url,
+      token: _config.token,
+      httpClient: _httpClient,
+    );
+  }
+
+  static Future<BandeiraClient> create(
+    BandeiraConfig config, {
+    http.Client? httpClient,
+  }) async {
+    final client = BandeiraClient(config, httpClient: httpClient);
+    try {
+      await client.start();
+      return client;
+    } catch (_) {
+      client.close();
+      rethrow;
+    }
+  }
+
+  final BandeiraConfig _config;
+  final http.Client _httpClient;
+  final bool _ownsHttpClient;
+  late final HttpFlagsRepository _repository;
+
+  Map<String, Flag> _flags = <String, Flag>{};
+  Timer? _pollTimer;
+  bool _started = false;
+  bool _closed = false;
+  bool _polling = false;
+
+  Future<void> start() async {
+    if (_closed) {
+      throw StateError('bandeira: client is closed');
+    }
+    if (_started) {
+      return;
+    }
+
+    await _refreshFlags();
+    _started = true;
+    _pollTimer = Timer.periodic(_config.pollInterval, (_) {
+      unawaited(_pollOnce());
+    });
+  }
+
+  void close() {
+    if (_closed) {
+      return;
+    }
+    _closed = true;
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    if (_ownsHttpClient) {
+      _httpClient.close();
+    }
+  }
+
+  bool isEnabled(String name, [BandeiraContext? context]) {
+    final flag = _flags[name];
+    if (flag == null) {
+      return false;
+    }
+    return isFlagEnabled(flag, context ?? const BandeiraContext());
+  }
+
+  Map<String, bool> allFlags() {
+    return Map<String, bool>.unmodifiable(
+      _flags.map((name, flag) => MapEntry(name, flag.enabled)),
+    );
+  }
+
+  void loadFlags(Map<String, dynamic> response) {
+    final parsed = ApiResponse.fromJson(response);
+    final byName = <String, Flag>{};
+    for (final flag in parsed.flags) {
+      byName[flag.name] = flag;
+    }
+    _flags = byName;
+  }
+
+  Future<void> _pollOnce() async {
+    if (_closed || _polling) {
+      return;
+    }
+    _polling = true;
+    try {
+      await _refreshFlags();
+    } catch (_) {
+      // Keep last known flags on polling errors.
+    } finally {
+      _polling = false;
+    }
+  }
+
+  Future<void> _refreshFlags() async {
+    final fetched = await _repository.fetchFlags();
+    _flags = fetched;
+  }
+}
+
+BandeiraConfig _validateConfig(BandeiraConfig config) {
+  if (config.url.trim().isEmpty) {
+    throw ArgumentError('bandeira: url is required');
+  }
+  if (config.token.trim().isEmpty) {
+    throw ArgumentError('bandeira: token is required');
+  }
+  if (config.pollInterval <= Duration.zero) {
+    throw ArgumentError('bandeira: pollInterval must be positive');
+  }
+  return config;
+}

--- a/dart/lib/src/evaluator.dart
+++ b/dart/lib/src/evaluator.dart
@@ -1,0 +1,234 @@
+import 'dart:convert';
+
+import 'flag_models.dart';
+import 'models.dart';
+
+bool isFlagEnabled(Flag flag, BandeiraContext context) {
+  if (!flag.enabled) {
+    return false;
+  }
+
+  if (flag.strategies.isEmpty) {
+    return true;
+  }
+
+  for (final strategy in flag.strategies) {
+    if (evaluateStrategy(strategy, context)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool evaluateStrategy(Strategy strategy, BandeiraContext context) {
+  for (final constraint in strategy.constraints) {
+    if (!evaluateConstraint(constraint, context)) {
+      return false;
+    }
+  }
+
+  switch (strategy.name) {
+    case 'default':
+      return true;
+    case 'userWithId':
+      return _evalUserWithId(strategy, context);
+    case 'gradualRollout':
+      return _evalGradualRollout(strategy, context);
+    case 'remoteAddress':
+      return _evalRemoteAddress(strategy, context);
+    default:
+      return true;
+  }
+}
+
+bool _evalUserWithId(Strategy strategy, BandeiraContext context) {
+  final rawUserIds = strategy.parameters['userIds'];
+  if (rawUserIds is! String) {
+    return false;
+  }
+
+  return splitMulti(rawUserIds).contains(context.userId);
+}
+
+bool _evalGradualRollout(Strategy strategy, BandeiraContext context) {
+  final rollout = _parseRollout(strategy.parameters['rollout']);
+  if (rollout == null) {
+    return false;
+  }
+
+  if (rollout >= 100) {
+    return true;
+  }
+  if (rollout <= 0) {
+    return false;
+  }
+
+  final stickiness = strategy.parameters['stickiness'] is String
+      ? strategy.parameters['stickiness'] as String
+      : 'userId';
+
+  final stickinessValue = switch (stickiness) {
+    'userId' => context.userId,
+    'sessionId' => context.sessionId,
+    _ => context.properties[stickiness] ?? '',
+  };
+
+  if (stickinessValue.isEmpty) {
+    return false;
+  }
+
+  final groupId = strategy.parameters['groupId'] is String
+      ? strategy.parameters['groupId'] as String
+      : '';
+
+  return normalizedHash('$stickinessValue$groupId') < rollout;
+}
+
+bool _evalRemoteAddress(Strategy strategy, BandeiraContext context) {
+  var rawIps = strategy.parameters['ips'];
+  rawIps ??= strategy.parameters['IPs'];
+  if (rawIps is! String) {
+    return false;
+  }
+
+  final remoteAddress = context.remoteAddress;
+  for (final entry in splitMulti(rawIps)) {
+    if (entry == remoteAddress) {
+      return true;
+    }
+    if (entry.endsWith('.') && remoteAddress.startsWith(entry)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool evaluateConstraint(Constraint constraint, BandeiraContext context) {
+  final contextValue = _getContextValue(constraint.contextName, context);
+  final result = _evaluateOperator(
+    constraint.operator,
+    contextValue,
+    constraint.values,
+    constraint.caseInsensitive,
+  );
+  return constraint.inverted ? !result : result;
+}
+
+String _getContextValue(String contextName, BandeiraContext context) {
+  return switch (contextName) {
+    'userId' => context.userId,
+    'sessionId' => context.sessionId,
+    'remoteAddress' => context.remoteAddress,
+    _ => context.properties[contextName] ?? '',
+  };
+}
+
+bool _evaluateOperator(
+  String op,
+  String contextValue,
+  List<String> values,
+  bool caseInsensitive,
+) {
+  final normalizedContextValue =
+      caseInsensitive ? contextValue.toLowerCase() : contextValue;
+  String normalize(String value) =>
+      caseInsensitive ? value.toLowerCase() : value;
+
+  switch (op) {
+    case 'IN':
+      return values.any((value) => normalizedContextValue == normalize(value));
+    case 'NOT_IN':
+      return values.every((value) => normalizedContextValue != normalize(value));
+    case 'STR_CONTAINS':
+      return values.any(
+        (value) => normalizedContextValue.contains(normalize(value)),
+      );
+    case 'STR_STARTS_WITH':
+      return values.any(
+        (value) => normalizedContextValue.startsWith(normalize(value)),
+      );
+    case 'STR_ENDS_WITH':
+      return values.any(
+        (value) => normalizedContextValue.endsWith(normalize(value)),
+      );
+    case 'NUM_EQ':
+    case 'NUM_GT':
+    case 'NUM_GTE':
+    case 'NUM_LT':
+    case 'NUM_LTE':
+      final number = double.tryParse(normalizedContextValue);
+      if (number == null) {
+        return false;
+      }
+      for (final value in values) {
+        final target = double.tryParse(value);
+        if (target == null) {
+          continue;
+        }
+        final matches = switch (op) {
+          'NUM_EQ' => number == target,
+          'NUM_GT' => number > target,
+          'NUM_GTE' => number >= target,
+          'NUM_LT' => number < target,
+          'NUM_LTE' => number <= target,
+          _ => false,
+        };
+        if (matches) {
+          return true;
+        }
+      }
+      return false;
+    case 'DATE_AFTER':
+    case 'DATE_BEFORE':
+      final valueDate = DateTime.tryParse(normalizedContextValue);
+      if (valueDate == null) {
+        return false;
+      }
+      for (final value in values) {
+        final targetDate = DateTime.tryParse(value);
+        if (targetDate == null) {
+          continue;
+        }
+        final matches = op == 'DATE_AFTER'
+            ? valueDate.isAfter(targetDate)
+            : valueDate.isBefore(targetDate);
+        if (matches) {
+          return true;
+        }
+      }
+      return false;
+    default:
+      return false;
+  }
+}
+
+List<String> splitMulti(String value) {
+  return value
+      .replaceAll('\r\n', ',')
+      .replaceAll('\n', ',')
+      .split(',')
+      .map((part) => part.trim())
+      .where((part) => part.isNotEmpty)
+      .toList(growable: false);
+}
+
+int normalizedHash(String value) {
+  var hash = 0x811C9DC5;
+  for (final byte in utf8.encode(value)) {
+    hash ^= byte;
+    hash = (hash * 0x01000193) & 0xFFFFFFFF;
+  }
+  return hash % 100;
+}
+
+int? _parseRollout(dynamic rawRollout) {
+  if (rawRollout is num) {
+    return rawRollout.toInt();
+  }
+  if (rawRollout is String) {
+    return int.tryParse(rawRollout);
+  }
+  return null;
+}

--- a/dart/lib/src/flag_models.dart
+++ b/dart/lib/src/flag_models.dart
@@ -1,0 +1,121 @@
+class ApiResponse {
+  ApiResponse({required this.flags});
+
+  final List<Flag> flags;
+
+  factory ApiResponse.fromJson(Map<String, dynamic> json) {
+    final flagsRaw = json['flags'];
+    final flagsList = flagsRaw is List ? flagsRaw : const [];
+    return ApiResponse(
+      flags: flagsList
+          .whereType<Map>()
+          .map(
+            (raw) => Flag.fromJson(
+              raw.map(
+                (key, value) => MapEntry(key.toString(), value),
+              ),
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+}
+
+class Flag {
+  Flag({
+    required this.name,
+    required this.enabled,
+    required this.strategies,
+  });
+
+  final String name;
+  final bool enabled;
+  final List<Strategy> strategies;
+
+  factory Flag.fromJson(Map<String, dynamic> json) {
+    final strategiesRaw = json['strategies'];
+    final strategiesList = strategiesRaw is List ? strategiesRaw : const [];
+    return Flag(
+      name: json['name'] is String ? json['name'] as String : '',
+      enabled: json['enabled'] is bool ? json['enabled'] as bool : false,
+      strategies: strategiesList
+          .whereType<Map>()
+          .map(
+            (raw) => Strategy.fromJson(
+              raw.map(
+                (key, value) => MapEntry(key.toString(), value),
+              ),
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+}
+
+class Strategy {
+  Strategy({
+    required this.name,
+    required this.parameters,
+    required this.constraints,
+  });
+
+  final String name;
+  final Map<String, dynamic> parameters;
+  final List<Constraint> constraints;
+
+  factory Strategy.fromJson(Map<String, dynamic> json) {
+    final constraintsRaw = json['constraints'];
+    final constraintsList = constraintsRaw is List ? constraintsRaw : const [];
+    final parametersRaw = json['parameters'];
+    return Strategy(
+      name: json['name'] is String ? json['name'] as String : '',
+      parameters: parametersRaw is Map
+          ? parametersRaw.map(
+              (key, value) => MapEntry(key.toString(), value),
+            )
+          : <String, dynamic>{},
+      constraints: constraintsList
+          .whereType<Map>()
+          .map(
+            (raw) => Constraint.fromJson(
+              raw.map(
+                (key, value) => MapEntry(key.toString(), value),
+              ),
+            ),
+          )
+          .toList(growable: false),
+    );
+  }
+}
+
+class Constraint {
+  Constraint({
+    required this.contextName,
+    required this.operator,
+    required this.values,
+    required this.inverted,
+    required this.caseInsensitive,
+  });
+
+  final String contextName;
+  final String operator;
+  final List<String> values;
+  final bool inverted;
+  final bool caseInsensitive;
+
+  factory Constraint.fromJson(Map<String, dynamic> json) {
+    final valuesRaw = json['values'];
+    final valuesList = valuesRaw is List ? valuesRaw : const [];
+    return Constraint(
+      contextName: json['context_name'] is String
+          ? json['context_name'] as String
+          : '',
+      operator: json['operator'] is String ? json['operator'] as String : '',
+      values: valuesList.map((value) => value.toString()).toList(growable: false),
+      inverted: json['inverted'] is bool ? json['inverted'] as bool : false,
+      caseInsensitive: json['case_insensitive'] is bool
+          ? json['case_insensitive'] as bool
+          : false,
+    );
+  }
+}

--- a/dart/lib/src/http_flags_repository.dart
+++ b/dart/lib/src/http_flags_repository.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'flag_models.dart';
+
+class HttpFlagsRepository {
+  HttpFlagsRepository({
+    required String url,
+    required String token,
+    required http.Client httpClient,
+  })  : _url = _trimTrailingSlashes(url),
+        _token = token,
+        _httpClient = httpClient;
+
+  final String _url;
+  final String _token;
+  final http.Client _httpClient;
+
+  Future<Map<String, Flag>> fetchFlags() async {
+    final response = await _httpClient.get(
+      Uri.parse('$_url/api/v1/flags'),
+      headers: <String, String>{
+        'Authorization': 'Bearer $_token',
+      },
+    );
+
+    if (response.statusCode != 200) {
+      throw StateError(
+        'bandeira: unexpected status ${response.statusCode}: ${response.body}',
+      );
+    }
+
+    final decoded = _decodeBody(response.body);
+    final apiResponse = ApiResponse.fromJson(decoded);
+    final byName = <String, Flag>{};
+    for (final flag in apiResponse.flags) {
+      byName[flag.name] = flag;
+    }
+    return byName;
+  }
+
+  Map<String, dynamic> _decodeBody(String body) {
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(body);
+    } catch (error) {
+      throw StateError('bandeira: failed to decode response: $error');
+    }
+
+    if (decoded is Map<String, dynamic>) {
+      return decoded;
+    }
+    if (decoded is Map) {
+      return decoded.map(
+        (key, value) => MapEntry(key.toString(), value),
+      );
+    }
+
+    throw StateError('bandeira: failed to decode response: expected object');
+  }
+}
+
+String _trimTrailingSlashes(String value) => value.replaceFirst(RegExp(r'/+$'), '');

--- a/dart/lib/src/models.dart
+++ b/dart/lib/src/models.dart
@@ -1,0 +1,25 @@
+class BandeiraConfig {
+  const BandeiraConfig({
+    required this.url,
+    required this.token,
+    this.pollInterval = const Duration(seconds: 15),
+  });
+
+  final String url;
+  final String token;
+  final Duration pollInterval;
+}
+
+class BandeiraContext {
+  const BandeiraContext({
+    this.userId = '',
+    this.sessionId = '',
+    this.remoteAddress = '',
+    this.properties = const <String, String>{},
+  });
+
+  final String userId;
+  final String sessionId;
+  final String remoteAddress;
+  final Map<String, String> properties;
+}

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -1,0 +1,16 @@
+name: bandeira
+description: Official Dart/Flutter client SDK for Bandeira feature flag service
+version: 0.1.0
+homepage: https://github.com/felipekafuri/bandeira-sdks
+repository: https://github.com/felipekafuri/bandeira-sdks/tree/main/dart
+issue_tracker: https://github.com/felipekafuri/bandeira-sdks/issues
+
+environment:
+  sdk: ">=3.3.0 <4.0.0"
+
+dependencies:
+  http: ^1.2.2
+
+dev_dependencies:
+  lints: ^5.0.0
+  test: ^1.25.8

--- a/dart/test/bandeira_test.dart
+++ b/dart/test/bandeira_test.dart
@@ -1,0 +1,543 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:bandeira/bandeira.dart';
+import 'package:test/test.dart';
+
+Map<String, dynamic> _loadFixtures() {
+  final raw = File('../testdata/flags.json').readAsStringSync();
+  final decoded = jsonDecode(raw);
+  if (decoded is Map<String, dynamic>) {
+    return decoded;
+  }
+  if (decoded is Map) {
+    return decoded.map((key, value) => MapEntry(key.toString(), value));
+  }
+  throw StateError('fixtures must decode to a JSON object');
+}
+
+final Map<String, dynamic> _fixtures = _loadFixtures();
+
+BandeiraClient createClientFromFixtures() {
+  final client = BandeiraClient(
+    const BandeiraConfig(
+      url: 'http://localhost:9999',
+      token: 'test-token',
+    ),
+  );
+  client.loadFlags(_fixtures);
+  return client;
+}
+
+Future<HttpServer> newTestServer(Map<String, dynamic> responseBody) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  server.listen((request) async {
+    if (request.uri.path != '/api/v1/flags') {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+
+    if (request.headers.value(HttpHeaders.authorizationHeader) !=
+        'Bearer test-token') {
+      request.response.statusCode = HttpStatus.unauthorized;
+      request.response.write('unauthorized');
+      await request.response.close();
+      return;
+    }
+
+    request.response.headers.contentType = ContentType.json;
+    request.response.write(jsonEncode(responseBody));
+    await request.response.close();
+  });
+  return server;
+}
+
+void main() {
+  group('BandeiraClient', () {
+    group('basic toggles', () {
+      test('enabled flag with no strategies returns true', () {
+        final client = createClientFromFixtures();
+        expect(client.isEnabled('simple-on'), isTrue);
+      });
+
+      test('disabled flag returns false', () {
+        final client = createClientFromFixtures();
+        expect(client.isEnabled('simple-off'), isFalse);
+      });
+
+      test('unknown flag returns false', () {
+        final client = createClientFromFixtures();
+        expect(client.isEnabled('nonexistent'), isFalse);
+      });
+    });
+
+    group('default strategy', () {
+      test('returns true', () {
+        final client = createClientFromFixtures();
+        expect(client.isEnabled('default-strategy'), isTrue);
+      });
+    });
+
+    group('userWithId', () {
+      test('matches a listed user', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'user-targeting',
+            const BandeiraContext(userId: 'user-42'),
+          ),
+          isTrue,
+        );
+      });
+
+      test('rejects an unlisted user', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'user-targeting',
+            const BandeiraContext(userId: 'user-99'),
+          ),
+          isFalse,
+        );
+      });
+
+      test('rejects when no context provided', () {
+        final client = createClientFromFixtures();
+        expect(client.isEnabled('user-targeting'), isFalse);
+      });
+
+      test('handles newline-separated user IDs', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'user-targeting-newlines',
+            const BandeiraContext(userId: 'user-42'),
+          ),
+          isTrue,
+        );
+        expect(
+          client.isEnabled(
+            'user-targeting-newlines',
+            const BandeiraContext(userId: 'user-99'),
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('gradualRollout', () {
+      test('100% rollout is always on', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'rollout-100',
+            const BandeiraContext(userId: 'anyone'),
+          ),
+          isTrue,
+        );
+      });
+
+      test('0% rollout is always off', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'rollout-0',
+            const BandeiraContext(userId: 'anyone'),
+          ),
+          isFalse,
+        );
+      });
+
+      test('no userId means no stickiness', () {
+        final client = createClientFromFixtures();
+        expect(client.isEnabled('rollout-50'), isFalse);
+      });
+
+      test('session stickiness uses sessionId', () {
+        final client = createClientFromFixtures();
+        final result = client.isEnabled(
+          'rollout-session-stickiness',
+          const BandeiraContext(sessionId: 'sess-123'),
+        );
+        expect(result, isA<bool>());
+      });
+    });
+
+    group('remoteAddress', () {
+      test('exact match', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'ip-allowlist',
+            const BandeiraContext(remoteAddress: '10.0.0.1'),
+          ),
+          isTrue,
+        );
+      });
+
+      test('prefix match', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'ip-allowlist',
+            const BandeiraContext(remoteAddress: '192.168.1.100'),
+          ),
+          isTrue,
+        );
+      });
+
+      test('no match', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'ip-allowlist',
+            const BandeiraContext(remoteAddress: '172.16.0.1'),
+          ),
+          isFalse,
+        );
+      });
+
+      test('legacy IPs key works', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'ip-allowlist-legacy',
+            const BandeiraContext(remoteAddress: '10.0.0.1'),
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    group('constraints', () {
+      test('IN operator matches', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-in',
+            const BandeiraContext(properties: <String, String>{'companyId': '2'}),
+          ),
+          isTrue,
+        );
+      });
+
+      test('IN operator rejects', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-in',
+            const BandeiraContext(properties: <String, String>{'companyId': '99'}),
+          ),
+          isFalse,
+        );
+      });
+
+      test('NOT_IN operator matches', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-not-in',
+            const BandeiraContext(properties: <String, String>{'plan': 'enterprise'}),
+          ),
+          isTrue,
+        );
+      });
+
+      test('NOT_IN operator rejects', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-not-in',
+            const BandeiraContext(properties: <String, String>{'plan': 'free'}),
+          ),
+          isFalse,
+        );
+      });
+
+      test('inverted constraint', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-inverted',
+            const BandeiraContext(properties: <String, String>{'plan': 'free'}),
+          ),
+          isFalse,
+        );
+        expect(
+          client.isEnabled(
+            'constraint-inverted',
+            const BandeiraContext(
+              properties: <String, String>{'plan': 'enterprise'},
+            ),
+          ),
+          isTrue,
+        );
+      });
+
+      test('case-insensitive constraint', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-case-insensitive',
+            const BandeiraContext(properties: <String, String>{'country': 'brazil'}),
+          ),
+          isTrue,
+        );
+        expect(
+          client.isEnabled(
+            'constraint-case-insensitive',
+            const BandeiraContext(properties: <String, String>{'country': 'PORTUGAL'}),
+          ),
+          isTrue,
+        );
+        expect(
+          client.isEnabled(
+            'constraint-case-insensitive',
+            const BandeiraContext(properties: <String, String>{'country': 'spain'}),
+          ),
+          isFalse,
+        );
+      });
+
+      test('STR_CONTAINS', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-str-contains',
+            const BandeiraContext(properties: <String, String>{'email': 'user@acme.com'}),
+          ),
+          isTrue,
+        );
+        expect(
+          client.isEnabled(
+            'constraint-str-contains',
+            const BandeiraContext(properties: <String, String>{'email': 'user@other.com'}),
+          ),
+          isFalse,
+        );
+      });
+
+      test('STR_STARTS_WITH', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-str-starts-with',
+            const BandeiraContext(properties: <String, String>{'email': 'admin@acme.com'}),
+          ),
+          isTrue,
+        );
+        expect(
+          client.isEnabled(
+            'constraint-str-starts-with',
+            const BandeiraContext(properties: <String, String>{'email': 'user@acme.com'}),
+          ),
+          isFalse,
+        );
+      });
+
+      test('STR_ENDS_WITH', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-str-ends-with',
+            const BandeiraContext(properties: <String, String>{'email': 'user@acme.com'}),
+          ),
+          isTrue,
+        );
+        expect(
+          client.isEnabled(
+            'constraint-str-ends-with',
+            const BandeiraContext(properties: <String, String>{'email': 'user@acme.io'}),
+          ),
+          isFalse,
+        );
+      });
+
+      test('NUM_GTE', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-num-gte',
+            const BandeiraContext(properties: <String, String>{'age': '21'}),
+          ),
+          isTrue,
+        );
+        expect(
+          client.isEnabled(
+            'constraint-num-gte',
+            const BandeiraContext(properties: <String, String>{'age': '18'}),
+          ),
+          isTrue,
+        );
+        expect(
+          client.isEnabled(
+            'constraint-num-gte',
+            const BandeiraContext(properties: <String, String>{'age': '16'}),
+          ),
+          isFalse,
+        );
+      });
+
+      test('DATE_AFTER', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constraint-date-after',
+            const BandeiraContext(
+              properties: <String, String>{'signupDate': '2026-06-15T00:00:00Z'},
+            ),
+          ),
+          isTrue,
+        );
+        expect(
+          client.isEnabled(
+            'constraint-date-after',
+            const BandeiraContext(
+              properties: <String, String>{'signupDate': '2025-06-15T00:00:00Z'},
+            ),
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('multi-strategy', () {
+      test('VIP user matches first strategy', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'multi-strategy',
+            const BandeiraContext(userId: 'vip-1'),
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    group('constrained rollout', () {
+      test('passes when constraint matches', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constrained-rollout',
+            const BandeiraContext(
+              userId: 'any-user',
+              properties: <String, String>{'companyId': 'acme'},
+            ),
+          ),
+          isTrue,
+        );
+      });
+
+      test('fails when constraint does not match', () {
+        final client = createClientFromFixtures();
+        expect(
+          client.isEnabled(
+            'constrained-rollout',
+            const BandeiraContext(
+              userId: 'any-user',
+              properties: <String, String>{'companyId': 'other'},
+            ),
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('allFlags', () {
+      test('returns all flags with their enabled state', () {
+        final client = createClientFromFixtures();
+        final flags = client.allFlags();
+        expect(flags['simple-on'], isTrue);
+        expect(flags['simple-off'], isFalse);
+      });
+    });
+
+    group('validation', () {
+      test('throws on missing url', () {
+        expect(
+          () => BandeiraClient(
+            const BandeiraConfig(
+              url: '',
+              token: 'test',
+            ),
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws on missing token', () {
+        expect(
+          () => BandeiraClient(
+            const BandeiraConfig(
+              url: 'http://localhost',
+              token: '',
+            ),
+          ),
+          throwsArgumentError,
+        );
+      });
+    });
+
+    group('startup APIs', () {
+      test('create performs initial fetch', () async {
+        final server = await newTestServer(_fixtures);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        final client = await BandeiraClient.create(
+          BandeiraConfig(
+            url: 'http://127.0.0.1:${server.port}',
+            token: 'test-token',
+            pollInterval: const Duration(hours: 1),
+          ),
+        );
+        addTearDown(client.close);
+
+        expect(client.isEnabled('simple-on'), isTrue);
+      });
+
+      test('start performs initial fetch', () async {
+        final server = await newTestServer(_fixtures);
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        final client = BandeiraClient(
+          BandeiraConfig(
+            url: 'http://127.0.0.1:${server.port}',
+            token: 'test-token',
+            pollInterval: const Duration(hours: 1),
+          ),
+        );
+        addTearDown(client.close);
+
+        await client.start();
+
+        expect(client.isEnabled('simple-on'), isTrue);
+      });
+
+      test('create fails fast when initial request fails', () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        server.listen((request) async {
+          request.response.statusCode = HttpStatus.unauthorized;
+          request.response.write('unauthorized');
+          await request.response.close();
+        });
+        addTearDown(() async {
+          await server.close(force: true);
+        });
+
+        final future = BandeiraClient.create(
+          BandeiraConfig(
+            url: 'http://127.0.0.1:${server.port}',
+            token: 'test-token',
+          ),
+        );
+        await expectLater(future, throwsA(isA<StateError>()));
+      });
+    });
+  });
+}

--- a/docs/plans/2026-02-19-dart-flutter-sdk-design.md
+++ b/docs/plans/2026-02-19-dart-flutter-sdk-design.md
@@ -1,0 +1,131 @@
+# Dart/Flutter SDK Design
+
+## Context
+This repository currently ships official Bandeira SDKs for Go, JavaScript/TypeScript, and Python. They share the same core behavior: poll `/api/v1/flags`, cache flags in memory, and evaluate strategies/constraints locally so runtime checks (`isEnabled`) never do network I/O.
+
+Goal: add a Dart SDK that is Flutter-compatible while preserving parity with existing SDK behavior and test fixtures.
+
+## Objectives
+- Provide a pure Dart package that works in Flutter and non-Flutter Dart environments.
+- Match strategy/constraint semantics from Go/JS/Python SDKs.
+- Support both startup styles:
+  - `await client.start()`
+  - `await BandeiraClient.create(config)`
+- Include CI testing and publishing workflow consistent with existing language SDKs.
+
+## Non-Goals
+- Splitting into separate `core` and Flutter wrapper packages in this PR.
+- Introducing reactive or stream-first APIs beyond parity requirements.
+- Adding server-side targeting features not already in shared fixtures and SDKs.
+
+## Architecture
+Package path: `dart/`
+
+Public API (exported from `lib/bandeira.dart`):
+- `BandeiraConfig`
+- `BandeiraContext`
+- `BandeiraClient`
+
+Implementation modules:
+- `lib/src/models.dart`
+  - API DTOs and context/config types.
+- `lib/src/evaluator.dart`
+  - Strategy and constraint evaluation logic.
+- `lib/src/http_flags_repository.dart`
+  - HTTP fetch + JSON decode for `/api/v1/flags`.
+- `lib/src/client.dart`
+  - Lifecycle (`start`, `create`, `close`), cache management, polling.
+
+Testing:
+- `test/bandeira_test.dart`
+- Shared fixture usage from `../testdata/flags.json` for parity with JS/Python tests.
+
+## Data Flow
+1. Client is constructed with `url`, `token`, optional `pollInterval`, optional custom HTTP client.
+2. `start()` and `create()` both perform initial fetch. Initial fetch errors are surfaced immediately.
+3. On success, flags are normalized into map keyed by flag name.
+4. Background timer polls at interval (default 15 seconds); successful responses atomically replace in-memory cache.
+5. `isEnabled(name, [context])` reads cache only and applies evaluation rules.
+6. `close()` cancels timer and closes owned HTTP resources.
+
+## Evaluation Rules
+### Flag-level behavior
+- Missing flag: `false`
+- Disabled flag: `false`
+- Enabled flag with no strategies: `true`
+- Enabled flag with strategies: OR across strategies
+
+### Strategy behavior
+- `default`: `true`
+- `userWithId`:
+  - read `parameters.userIds` (string)
+  - split by commas/newlines
+  - match against `context.userId`
+- `gradualRollout`:
+  - parse `parameters.rollout` from number/string
+  - `>=100 => true`, `<=0 => false`
+  - stickiness from `parameters.stickiness` (`userId`, `sessionId`, or property key)
+  - optional `groupId`
+  - deterministic bucket via FNV-1a 32-bit hash mod 100
+- `remoteAddress`:
+  - accept `ips` and legacy `IPs`
+  - exact match or prefix entries ending with `.`
+- unknown strategy: `true` (fail-open parity)
+
+### Constraints behavior
+Each strategy enforces AND across constraints.
+
+Supported operators:
+- `IN`, `NOT_IN`
+- `STR_CONTAINS`, `STR_STARTS_WITH`, `STR_ENDS_WITH`
+- `NUM_EQ`, `NUM_GT`, `NUM_GTE`, `NUM_LT`, `NUM_LTE`
+- `DATE_AFTER`, `DATE_BEFORE`
+
+Constraint fields:
+- `inverted`: negate result
+- `case_insensitive`: lower-case comparisons for string operators
+
+Unknown operators return `false`.
+
+## Error Handling
+- Missing `url`/`token`: `ArgumentError`.
+- Initial fetch failure: throw to caller (`start`/`create`).
+- Polling failures: swallowed to preserve last known good cache.
+- Non-200 responses and invalid JSON include diagnostic context where possible.
+
+## Testing Strategy
+- Use `testdata/flags.json` fixture to match JS/Python behavioral coverage.
+- Cover:
+  - basic toggles
+  - default strategy
+  - user targeting (comma/newline)
+  - gradual rollout (0/100/session stickiness)
+  - remote address (`ips` and `IPs`)
+  - all constraint operators used by current fixture suite
+  - multi-strategy OR behavior
+  - constrained rollout
+  - constructor validation
+  - `allFlags` snapshot
+- Add a small fetch/start lifecycle test with a local HTTP server stub.
+
+## Packaging and CI
+- Add `dart/pubspec.yaml` metadata and dependencies (`http` package).
+- Add package README and example usage.
+- Add `dart` CI workflow for pull requests and pushes touching `dart/**` or `testdata/**`.
+- Add tag-triggered publish workflow (e.g. tags matching `dart/v*`) using `dart pub publish --force` with repository secret token.
+- Update repo root README SDK table and quick-start snippets.
+
+## Risks and Mitigations
+- Date parsing semantics can differ subtly across languages.
+  - Mitigation: keep fixture-driven tests aligned with existing suite assumptions.
+- Hash bucketing mismatch would break rollout parity.
+  - Mitigation: implement FNV-1a explicitly and test deterministic outputs.
+- Polling resource leaks in Flutter hot-reload/dev cycles.
+  - Mitigation: make `close()` idempotent and clearly documented.
+
+## Rollout Plan
+1. Add Dart package and parity tests.
+2. Run tests locally.
+3. Add CI and publish workflow.
+4. Update root docs.
+5. Open PR with behavior parity summary and release tagging instructions.

--- a/docs/plans/2026-02-19-dart-flutter-sdk.md
+++ b/docs/plans/2026-02-19-dart-flutter-sdk.md
@@ -1,0 +1,477 @@
+# Dart/Flutter SDK Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build and ship an official Dart/Flutter-compatible Bandeira SDK with behavior parity to the Go, JS/TS, and Python SDKs, including tests, CI, and tag-based publish workflow.
+
+**Architecture:** Add a pure Dart package at `dart/` with a small public API (`BandeiraConfig`, `BandeiraContext`, `BandeiraClient`) and internal modules for models, HTTP fetch, and strategy/constraint evaluation. Cache flags in-memory and poll in the background; evaluate `isEnabled` from cache only.
+
+**Tech Stack:** Dart 3 (`http`, `test`, `lints`), GitHub Actions.
+
+---
+
+### Task 1: Scaffold Dart package metadata and entrypoint
+
+**Files:**
+- Create: `dart/pubspec.yaml`
+- Create: `dart/README.md`
+- Create: `dart/analysis_options.yaml`
+- Create: `dart/lib/bandeira.dart`
+
+**Step 1: Write the failing test**
+
+```dart
+import 'package:bandeira/bandeira.dart';
+
+void main() {
+  final cfg = BandeiraConfig(url: 'http://localhost', token: 't');
+  final client = BandeiraClient(cfg);
+  client.close();
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd dart && dart analyze`
+Expected: FAIL with unresolved package/library symbols.
+
+**Step 3: Write minimal implementation**
+
+```dart
+library bandeira;
+
+export 'src/client.dart';
+export 'src/models.dart';
+```
+
+Also add package metadata and dependencies in `pubspec.yaml`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd dart && dart pub get && dart analyze`
+Expected: PASS with no unresolved package errors.
+
+**Step 5: Commit**
+
+```bash
+git add dart/pubspec.yaml dart/README.md dart/analysis_options.yaml dart/lib/bandeira.dart
+git commit -m "feat(dart): scaffold package metadata and exports"
+```
+
+### Task 2: Implement public models and API response parsing
+
+**Files:**
+- Create: `dart/lib/src/models.dart`
+- Test: `dart/test/models_test.dart`
+
+**Step 1: Write the failing test**
+
+```dart
+import 'package:test/test.dart';
+import 'package:bandeira/bandeira.dart';
+
+void main() {
+  test('parses API flags payload', () {
+    final response = ApiResponse.fromJson({'flags': []});
+    expect(response.flags, isEmpty);
+  });
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd dart && dart test test/models_test.dart`
+Expected: FAIL with missing `ApiResponse` model.
+
+**Step 3: Write minimal implementation**
+
+```dart
+class BandeiraConfig { ... }
+class BandeiraContext { ... }
+class ApiResponse { ... }
+class Flag { ... }
+class Strategy { ... }
+class Constraint { ... }
+```
+
+Include safe defaults for missing JSON fields and helpers for dynamic parameter access.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd dart && dart test test/models_test.dart`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add dart/lib/src/models.dart dart/test/models_test.dart
+git commit -m "feat(dart): add config/context and flag response models"
+```
+
+### Task 3: Implement evaluator helpers (split + hash + operator core)
+
+**Files:**
+- Create: `dart/lib/src/evaluator.dart`
+- Test: `dart/test/evaluator_helpers_test.dart`
+
+**Step 1: Write the failing test**
+
+```dart
+import 'package:test/test.dart';
+import 'package:bandeira/src/evaluator.dart';
+
+void main() {
+  test('splitMulti handles newlines and commas', () {
+    expect(splitMulti('a,b\nc'), ['a', 'b', 'c']);
+  });
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd dart && dart test test/evaluator_helpers_test.dart`
+Expected: FAIL with missing helpers.
+
+**Step 3: Write minimal implementation**
+
+```dart
+List<String> splitMulti(String s) { ... }
+int normalizedHash(String value) { ... } // FNV-1a 32-bit, mod 100
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd dart && dart test test/evaluator_helpers_test.dart`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add dart/lib/src/evaluator.dart dart/test/evaluator_helpers_test.dart
+git commit -m "feat(dart): add evaluator helpers for split and hashing"
+```
+
+### Task 4: Implement full strategy and constraint evaluation
+
+**Files:**
+- Modify: `dart/lib/src/evaluator.dart`
+- Test: `dart/test/evaluator_logic_test.dart`
+
+**Step 1: Write the failing test**
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:bandeira/bandeira.dart';
+
+void main() {
+  late ApiResponse fixtures;
+
+  setUpAll(() {
+    final raw = File('../testdata/flags.json').readAsStringSync();
+    fixtures = ApiResponse.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+  });
+
+  test('userWithId newline targeting', () {
+    final flag = fixtures.flags.firstWhere((f) => f.name == 'user-targeting-newlines');
+    final enabled = evaluateFlag(flag, const BandeiraContext(userId: 'user-42'));
+    expect(enabled, isTrue);
+  });
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd dart && dart test test/evaluator_logic_test.dart`
+Expected: FAIL due to incomplete strategy/constraint evaluator.
+
+**Step 3: Write minimal implementation**
+
+```dart
+bool evaluateFlag(Flag flag, BandeiraContext ctx) { ... }
+bool evaluateStrategy(Strategy strategy, BandeiraContext ctx) { ... }
+bool evaluateConstraint(Constraint constraint, BandeiraContext ctx) { ... }
+```
+
+Implement all parity behavior:
+- Strategies: `default`, `userWithId`, `gradualRollout`, `remoteAddress`, unknown strategy fail-open.
+- Constraints/operators: `IN`, `NOT_IN`, string ops, numeric ops, date ops, inverted/case-insensitive.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd dart && dart test test/evaluator_logic_test.dart`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add dart/lib/src/evaluator.dart dart/test/evaluator_logic_test.dart
+git commit -m "feat(dart): implement strategy and constraint evaluator"
+```
+
+### Task 5: Implement HTTP repository and error shaping
+
+**Files:**
+- Create: `dart/lib/src/http_flags_repository.dart`
+- Test: `dart/test/http_flags_repository_test.dart`
+
+**Step 1: Write the failing test**
+
+```dart
+test('throws on non-200 response', () async {
+  final repo = HttpFlagsRepository(...);
+  expect(repo.fetchFlags(), throwsA(isA<StateError>()));
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd dart && dart test test/http_flags_repository_test.dart`
+Expected: FAIL due to missing repository.
+
+**Step 3: Write minimal implementation**
+
+```dart
+class HttpFlagsRepository {
+  Future<Map<String, Flag>> fetchFlags() async { ... }
+}
+```
+
+Include:
+- URL normalization
+- Bearer token header
+- JSON decode into `ApiResponse`
+- status/body in thrown error message
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd dart && dart test test/http_flags_repository_test.dart`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add dart/lib/src/http_flags_repository.dart dart/test/http_flags_repository_test.dart
+git commit -m "feat(dart): add HTTP flags fetch repository"
+```
+
+### Task 6: Implement `BandeiraClient` lifecycle, polling, and APIs
+
+**Files:**
+- Create: `dart/lib/src/client.dart`
+- Test: `dart/test/client_lifecycle_test.dart`
+
+**Step 1: Write the failing test**
+
+```dart
+test('create() performs initial fetch and serves flags', () async {
+  final client = await BandeiraClient.create(BandeiraConfig(...));
+  expect(client.isEnabled('simple-on'), isTrue);
+  await client.close();
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd dart && dart test test/client_lifecycle_test.dart`
+Expected: FAIL due to missing client implementation.
+
+**Step 3: Write minimal implementation**
+
+```dart
+class BandeiraClient {
+  BandeiraClient(BandeiraConfig config, {http.Client? httpClient});
+  static Future<BandeiraClient> create(BandeiraConfig config, {http.Client? httpClient});
+  Future<void> start();
+  bool isEnabled(String name, [BandeiraContext? ctx]);
+  Map<String, bool> allFlags();
+  void loadFlags(Map<String, dynamic> response);
+  Future<void> close();
+}
+```
+
+Implementation requirements:
+- fail-fast on initial fetch
+- background polling with `Timer.periodic`
+- swallow polling errors
+- idempotent `start` and `close`
+- cache replacement as atomic map assignment
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd dart && dart test test/client_lifecycle_test.dart`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add dart/lib/src/client.dart dart/test/client_lifecycle_test.dart
+git commit -m "feat(dart): add client lifecycle and polling"
+```
+
+### Task 7: Add parity fixture test suite using shared `testdata/flags.json`
+
+**Files:**
+- Create: `dart/test/bandeira_test.dart`
+
+**Step 1: Write the failing test**
+
+```dart
+test('unknown flag returns false', () {
+  final c = createClientFromFixtures();
+  expect(c.isEnabled('nonexistent'), isFalse);
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd dart && dart test test/bandeira_test.dart`
+Expected: FAIL until fixture harness and parity cases are complete.
+
+**Step 3: Write minimal implementation**
+
+Add full parity cases equivalent to JS/Python:
+- basic toggles
+- default strategy
+- user targeting + newline format
+- rollout 0/100/no stickiness/session
+- remoteAddress + legacy `IPs`
+- all constraints in fixture
+- multi-strategy OR logic
+- constrained rollout
+- `allFlags`
+- input validation (`url`, `token`)
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd dart && dart test test/bandeira_test.dart`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add dart/test/bandeira_test.dart
+git commit -m "test(dart): add fixture parity suite"
+```
+
+### Task 8: Improve docs and add usage examples
+
+**Files:**
+- Modify: `dart/README.md`
+- Modify: `README.md`
+
+**Step 1: Write the failing test**
+
+```text
+N/A (docs task)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `rg "Dart|Flutter" README.md`
+Expected: no Dart/Flutter SDK entry present.
+
+**Step 3: Write minimal implementation**
+
+Update docs with:
+- root SDK table row for Dart/Flutter
+- install command (`dart pub add bandeira`)
+- quick start snippets showing both `create()` and `start()` styles
+- close semantics and context examples
+
+**Step 4: Run test to verify it passes**
+
+Run: `rg "Dart|Flutter" README.md dart/README.md`
+Expected: Dart/Flutter docs present.
+
+**Step 5: Commit**
+
+```bash
+git add README.md dart/README.md
+git commit -m "docs: add dart/flutter SDK usage docs"
+```
+
+### Task 9: Add GitHub Actions workflow for Dart test + publish
+
+**Files:**
+- Create: `.github/workflows/dart.yml`
+
+**Step 1: Write the failing test**
+
+```text
+N/A (workflow task)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `test -f .github/workflows/dart.yml || echo missing`
+Expected: `missing`.
+
+**Step 3: Write minimal implementation**
+
+Workflow requirements:
+- `name: Dart SDK`
+- triggers:
+  - push/pr when `dart/**` or `testdata/**` changes
+  - tag push `dart/v*`
+- test job:
+  - checkout
+  - setup Dart stable
+  - `dart pub get`, `dart analyze`, `dart test`
+- publish job:
+  - needs test
+  - only runs for `refs/tags/dart/v*`
+  - uses `PUB_CREDENTIALS_JSON` secret to write `$HOME/.pub-cache/credentials.json`
+  - `dart pub publish --force`
+
+**Step 4: Run test to verify it passes**
+
+Run: `rg "name: Dart SDK|dart/v\*|dart pub publish" .github/workflows/dart.yml`
+Expected: workflow contains required CI/publish markers.
+
+**Step 5: Commit**
+
+```bash
+git add .github/workflows/dart.yml
+git commit -m "ci: add dart SDK test and publish workflow"
+```
+
+### Task 10: Final verification and PR preparation
+
+**Files:**
+- Modify: `dart/**` (if fixes needed)
+- Modify: `.github/workflows/dart.yml` (if fixes needed)
+- Modify: `README.md` (if fixes needed)
+
+**Step 1: Write the failing test**
+
+```text
+N/A (integration verification)
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd dart && dart analyze && dart test`
+Expected: if failures appear, capture and fix.
+
+**Step 3: Write minimal implementation**
+
+Fix lint/test issues and API/doc inconsistencies discovered in full run.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `cd dart && dart analyze && dart test`
+- `git status --short`
+
+Expected:
+- all analyzer/tests pass
+- clean git state except intended tracked changes
+
+**Step 5: Commit**
+
+```bash
+git add dart .github/workflows/dart.yml README.md
+git commit -m "feat: add official Dart/Flutter SDK"
+```

--- a/docs/plans/2026-02-19-elixir-sdk-design.md
+++ b/docs/plans/2026-02-19-elixir-sdk-design.md
@@ -1,0 +1,130 @@
+# Elixir SDK Design
+
+## Context
+This repository already ships official Bandeira SDKs for Go, JavaScript/TypeScript, Python, and Dart. All SDKs share the same operating model: poll `/api/v1/flags`, cache flags in memory, and evaluate strategies locally so runtime checks never do network I/O.
+
+Goal: add an official Elixir SDK with strict behavior parity (no extra features) and release automation consistent with existing SDK workflows.
+
+## Objectives
+- Build an OTP-first Elixir client using a supervised `GenServer`.
+- Keep strategy/constraint semantics aligned with existing SDKs and shared fixtures in `testdata/flags.json`.
+- Provide Hex publishing automation on version tags.
+- Keep public API minimal and parity-focused.
+
+## Non-Goals
+- Adding telemetry, metrics hooks, fallback value APIs, or additional product behavior.
+- Deviating from shared fixture semantics.
+- Building multiple packaging variants in this PR.
+
+## Architecture
+Package path: `elixir/`
+
+Public API:
+- `Bandeira.Config`
+- `Bandeira.Context`
+- `Bandeira.Client`
+
+`Bandeira.Client` is an OTP `GenServer` exposing:
+- `start_link/1`
+- `is_enabled/3`
+- `all_flags/1`
+- `close/1`
+- `load_flags/2` (test-parity helper)
+
+Internal modules:
+- `Bandeira.FlagModels` for normalized decoded payload structs.
+- `Bandeira.HTTPFlagsRepository` for HTTP fetch and decode from `/api/v1/flags`.
+- `Bandeira.Evaluator` for strategy + constraint evaluation.
+
+State model:
+- `%{config: ..., flags_by_name: %{}, timer_ref: ...}`
+- Initial fetch in `start_link/1` fails fast.
+- Periodic polling replaces cache atomically.
+
+## Data Flow and Lifecycle
+1. `start_link/1` validates required `url` and `token`.
+2. Initial fetch loads flags before the process is considered ready.
+3. Polling is scheduled with `Process.send_after/3` using configured interval (default 15s).
+4. Poll success updates `flags_by_name`; poll failure keeps last known good cache.
+5. `is_enabled/3` reads in-memory cache only and applies evaluation rules.
+6. `all_flags/1` returns `%{flag_name => enabled_boolean}` snapshot.
+7. `close/1` stops the client process cleanly.
+
+## Evaluation Rules (Parity)
+### Flag behavior
+- Missing flag: `false`
+- Disabled flag: `false`
+- Enabled flag without strategies: `true`
+- Enabled flag with strategies: OR across strategies
+
+### Strategy behavior
+- `default`: `true`
+- `userWithId`:
+  - Read `parameters.userIds` as string
+  - Split on commas/newlines
+  - Match against `context.user_id`
+- `gradualRollout`:
+  - Parse `parameters.rollout` from number/string
+  - `>=100 => true`, `<=0 => false`
+  - `stickiness` from `userId`, `sessionId`, or custom property key
+  - Optional `groupId`
+  - Deterministic bucket via FNV-1a 32-bit hash mod 100
+- `remoteAddress`:
+  - Accept both `ips` and legacy `IPs`
+  - Exact address match or prefix match for entries ending with `.`
+- Unknown strategy: `true` (fail-open parity)
+
+### Constraint behavior
+- AND across constraints in a strategy.
+- Operators:
+  - `IN`, `NOT_IN`
+  - `STR_CONTAINS`, `STR_STARTS_WITH`, `STR_ENDS_WITH`
+  - `NUM_EQ`, `NUM_GT`, `NUM_GTE`, `NUM_LT`, `NUM_LTE`
+  - `DATE_AFTER`, `DATE_BEFORE`
+- `inverted`: negates result.
+- `case_insensitive`: lowercase compare for string operators.
+- Unknown operator: `false`.
+
+## Error Handling
+- Missing URL/token: argument validation error.
+- Initial fetch failure: return startup error (fail fast).
+- Polling failure: swallow error and keep cache.
+- Non-200 responses include status/body in message.
+- Invalid JSON returns decode failure error.
+
+## Testing Strategy
+- Reuse shared fixture file `testdata/flags.json` for parity assertions.
+- ExUnit coverage for:
+  - basic toggles
+  - default strategy
+  - user targeting (comma/newline)
+  - gradual rollout (0/100/stickiness)
+  - remote address (`ips` and `IPs`)
+  - constraint operators used by fixtures
+  - multi-strategy OR
+  - constrained rollout
+  - validation and `all_flags`
+- Add local HTTP server tests for startup fetch and auth header behavior.
+
+## CI and Publishing
+- Add `.github/workflows/elixir.yml`:
+  - Test on pushes/PRs affecting `elixir/**` and `testdata/**`
+  - Publish on tags `elixir/v*`
+- Publish job uses `HEX_API_KEY` repository secret with `mix hex.publish --yes`.
+
+## Documentation
+- Add `elixir/README.md` with install and supervision usage.
+- Update root `README.md` SDK table and quick-start section with Elixir sample.
+
+## Risks and Mitigations
+- Hash or operator mismatch could break parity.
+  - Mitigation: fixture-driven tests matching other SDKs.
+- Polling lifecycle bugs in long-running processes.
+  - Mitigation: OTP `GenServer`, idempotent close behavior, focused lifecycle tests.
+
+## Rollout Plan
+1. Scaffold Elixir Mix project + modules.
+2. Implement evaluator/repository/client with parity logic.
+3. Add fixture-based tests and lifecycle tests.
+4. Add CI + publish workflow.
+5. Update docs and open PR with parity summary.

--- a/docs/plans/2026-02-19-elixir-sdk.md
+++ b/docs/plans/2026-02-19-elixir-sdk.md
@@ -1,0 +1,273 @@
+# Elixir SDK Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build an official OTP-first Elixir SDK for Bandeira with strict behavior parity to existing SDKs, including tests, CI, docs, and Hex publish automation.
+
+**Architecture:** Implement `Bandeira.Client` as a `GenServer` that performs fail-fast initial fetch, stores flags in-memory, polls periodically, and evaluates `is_enabled` locally. Keep evaluation logic in a dedicated module and parse API payloads into normalized structs for predictable behavior.
+
+**Tech Stack:** Elixir/Mix, OTP `GenServer`, `Req` for HTTP, ExUnit, GitHub Actions.
+
+---
+
+### Task 1: Scaffold Mix project and package metadata
+
+**Files:**
+- Create: `elixir/.formatter.exs`
+- Create: `elixir/.gitignore`
+- Create: `elixir/mix.exs`
+- Create: `elixir/lib/bandeira.ex`
+- Create: `elixir/lib/bandeira/config.ex`
+- Create: `elixir/lib/bandeira/context.ex`
+- Create: `elixir/README.md`
+
+**Step 1: Write the failing test**
+
+```elixir
+defmodule BandeiraCompileSmokeTest do
+  use ExUnit.Case
+
+  test "public modules compile" do
+    assert Code.ensure_loaded?(Bandeira.Client)
+  end
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd elixir && mix test`
+Expected: FAIL because project/modules do not exist.
+
+**Step 3: Write minimal implementation**
+
+- Add Mix project metadata (`name`, `version`, package links, deps).
+- Add module exports and config/context structs.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd elixir && mix format && mix test`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add elixir/.formatter.exs elixir/.gitignore elixir/mix.exs elixir/lib/bandeira.ex elixir/lib/bandeira/config.ex elixir/lib/bandeira/context.ex elixir/README.md
+git commit -m "feat(elixir): scaffold mix package and public types"
+```
+
+### Task 2: Implement models and evaluator
+
+**Files:**
+- Create: `elixir/lib/bandeira/flag_models.ex`
+- Create: `elixir/lib/bandeira/evaluator.ex`
+- Test: `elixir/test/bandeira/evaluator_test.exs`
+
+**Step 1: Write the failing test**
+
+```elixir
+test "userWithId handles newline-separated ids" do
+  client = start_fixture_client()
+  assert Bandeira.Client.is_enabled(client, "user-targeting-newlines", %Bandeira.Context{user_id: "user-42"})
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd elixir && mix test test/bandeira/evaluator_test.exs`
+Expected: FAIL due to missing evaluator/model behavior.
+
+**Step 3: Write minimal implementation**
+
+- Parse payload into typed structs.
+- Implement strategy and constraint evaluation parity:
+  - `default`, `userWithId`, `gradualRollout`, `remoteAddress`
+  - operators + `inverted` + `case_insensitive`
+  - FNV-1a hash mod 100.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd elixir && mix test test/bandeira/evaluator_test.exs`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add elixir/lib/bandeira/flag_models.ex elixir/lib/bandeira/evaluator.ex elixir/test/bandeira/evaluator_test.exs
+git commit -m "feat(elixir): add flag models and evaluator parity logic"
+```
+
+### Task 3: Implement HTTP repository and GenServer client lifecycle
+
+**Files:**
+- Create: `elixir/lib/bandeira/http_flags_repository.ex`
+- Create: `elixir/lib/bandeira/client.ex`
+- Modify: `elixir/lib/bandeira.ex`
+- Test: `elixir/test/bandeira/client_test.exs`
+
+**Step 1: Write the failing test**
+
+```elixir
+test "start_link fails fast on unauthorized initial fetch" do
+  assert {:error, _} = Bandeira.Client.start_link(%Bandeira.Config{url: server_url(), token: "bad"})
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd elixir && mix test test/bandeira/client_test.exs`
+Expected: FAIL due to missing client/repository.
+
+**Step 3: Write minimal implementation**
+
+- Repository fetches `/api/v1/flags` with bearer auth and decodes JSON.
+- `Bandeira.Client`:
+  - `start_link/1` fail-fast initial fetch
+  - periodic polling
+  - `is_enabled/3`, `all_flags/1`, `load_flags/2`, `close/1`
+  - keep last-known-good cache on poll errors.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd elixir && mix test test/bandeira/client_test.exs`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add elixir/lib/bandeira/http_flags_repository.ex elixir/lib/bandeira/client.ex elixir/lib/bandeira.ex elixir/test/bandeira/client_test.exs
+git commit -m "feat(elixir): add polling client and HTTP repository"
+```
+
+### Task 4: Add comprehensive parity tests using shared fixtures
+
+**Files:**
+- Create: `elixir/test/support/fixtures.ex`
+- Modify: `elixir/test/bandeira/evaluator_test.exs`
+- Modify: `elixir/test/test_helper.exs`
+
+**Step 1: Write the failing test**
+
+```elixir
+test "constraint DATE_AFTER parity" do
+  client = start_fixture_client()
+  assert Bandeira.Client.is_enabled(client, "constraint-date-after", %Bandeira.Context{properties: %{"signupDate" => "2026-06-15T00:00:00Z"}})
+end
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd elixir && mix test`
+Expected: FAIL for unimplemented or mismatched parity cases.
+
+**Step 3: Write minimal implementation**
+
+- Cover all fixture scenarios mirrored by JS/Python/Dart tests:
+  - toggles, strategies, constraints, multi-strategy, constrained rollout, all_flags.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd elixir && mix test`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add elixir/test/support/fixtures.ex elixir/test/bandeira/evaluator_test.exs elixir/test/test_helper.exs
+git commit -m "test(elixir): add fixture-driven parity coverage"
+```
+
+### Task 5: Add GitHub Actions workflow for test and Hex publish
+
+**Files:**
+- Create: `.github/workflows/elixir.yml`
+
+**Step 1: Write the failing test**
+
+- N/A (workflow change).
+
+**Step 2: Validate workflow config**
+
+Run: `rg "name: Elixir SDK" .github/workflows/elixir.yml`
+Expected: File exists with expected triggers and jobs.
+
+**Step 3: Write minimal implementation**
+
+- Test job for `elixir/**` and `testdata/**`.
+- Publish job gated on `refs/tags/elixir/v*` and using `HEX_API_KEY`.
+
+**Step 4: Verify**
+
+Run: `sed -n '1,260p' .github/workflows/elixir.yml`
+Expected: Correct triggers, test steps, publish gating.
+
+**Step 5: Commit**
+
+```bash
+git add .github/workflows/elixir.yml
+git commit -m "ci(elixir): add test and hex publish workflow"
+```
+
+### Task 6: Update documentation and root SDK index
+
+**Files:**
+- Modify: `README.md`
+- Modify: `elixir/README.md`
+
+**Step 1: Write the failing test**
+
+- N/A (docs change).
+
+**Step 2: Validate missing references**
+
+Run: `rg "Elixir" README.md elixir/README.md`
+Expected: Initially missing or incomplete.
+
+**Step 3: Write minimal implementation**
+
+- Add Elixir row to SDK table.
+- Add Elixir quick-start in root README.
+- Add package usage details in `elixir/README.md`.
+
+**Step 4: Verify docs**
+
+Run: `sed -n '1,260p' README.md && sed -n '1,260p' elixir/README.md`
+Expected: Consistent install + usage instructions.
+
+**Step 5: Commit**
+
+```bash
+git add README.md elixir/README.md
+git commit -m "docs: add Elixir SDK usage and index"
+```
+
+### Task 7: Final validation and PR preparation
+
+**Files:**
+- Modify: `docs/plans/2026-02-19-elixir-sdk-design.md`
+- Modify: `docs/plans/2026-02-19-elixir-sdk.md`
+
+**Step 1: Run full checks**
+
+Run: `cd elixir && mix format && mix test`
+Expected: PASS.
+
+**Step 2: Review diff and summarize**
+
+Run: `git status --short && git diff --stat`
+Expected: Only planned files changed.
+
+**Step 3: Commit docs and final touches**
+
+```bash
+git add docs/plans/2026-02-19-elixir-sdk-design.md docs/plans/2026-02-19-elixir-sdk.md
+git commit -m "docs: add elixir sdk design and implementation plan"
+```
+
+**Step 4: Push branch and open PR**
+
+Run:
+```bash
+git push -u fork <branch-name>
+gh pr create --base main --head <branch-name> --title "feat: add official Elixir SDK" --body-file /tmp/pr.md
+```
+Expected: PR URL returned.

--- a/elixir/.formatter.exs
+++ b/elixir/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/elixir/.gitignore
+++ b/elixir/.gitignore
@@ -1,0 +1,6 @@
+/_build/
+/deps/
+/cover/
+/doc/
+/.elixir_ls/
+*.ez

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -1,0 +1,46 @@
+# Bandeira Elixir SDK
+
+Official Elixir client SDK for [Bandeira](https://github.com/felipekafuri/bandeira), a self-hosted feature flag service.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:bandeira, "~> 0.1.0"}
+  ]
+end
+```
+
+Then run:
+
+```bash
+mix deps.get
+```
+
+## Usage
+
+```elixir
+alias Bandeira.{Client, Config, Context}
+
+{:ok, client} =
+  Client.start_link(%Config{
+    url: "http://localhost:8080",
+    token: "your-client-token"
+  })
+
+if Client.is_enabled(client, "my-flag", %Context{user_id: "user-123"}) do
+  # feature is on
+end
+
+Client.close(client)
+```
+
+## Notes
+
+- The client polls `/api/v1/flags` in the background and caches flags in memory.
+- `is_enabled/3` is a pure in-memory lookup and does not do network I/O.
+- Initial startup fails fast if the first fetch fails.
+- Call `close/1` when running unmanaged clients.

--- a/elixir/lib/bandeira.ex
+++ b/elixir/lib/bandeira.ex
@@ -1,0 +1,28 @@
+defmodule Bandeira do
+  @moduledoc """
+  Official Elixir client SDK for Bandeira feature flags.
+
+  The client polls Bandeira in the background, stores flags in memory,
+  and evaluates strategies locally.
+  """
+
+  alias Bandeira.Client
+  alias Bandeira.Config
+  alias Bandeira.Context
+
+  @doc "Starts a Bandeira client process."
+  @spec start_link(Config.t() | map() | keyword(), keyword()) :: GenServer.on_start()
+  def start_link(config, opts \\ []), do: Client.start_link(config, opts)
+
+  @doc "Returns true if the given flag is enabled for the provided context."
+  @spec is_enabled(GenServer.server(), String.t(), Context.t() | map() | nil) :: boolean()
+  def is_enabled(client, name, context \\ nil), do: Client.is_enabled(client, name, context)
+
+  @doc "Returns all known flags and their enabled state."
+  @spec all_flags(GenServer.server()) :: %{optional(String.t()) => boolean()}
+  def all_flags(client), do: Client.all_flags(client)
+
+  @doc "Stops the Bandeira client process."
+  @spec close(GenServer.server()) :: :ok
+  def close(client), do: Client.close(client)
+end

--- a/elixir/lib/bandeira/client.ex
+++ b/elixir/lib/bandeira/client.ex
@@ -1,0 +1,90 @@
+defmodule Bandeira.Client do
+  @moduledoc """
+  OTP client for Bandeira feature flags.
+  """
+
+  use GenServer
+
+  alias Bandeira.Config
+  alias Bandeira.Context
+  alias Bandeira.Evaluator
+  alias Bandeira.HTTPFlagsRepository
+
+  @type state :: %{
+          config: Config.t(),
+          flags_by_name: map(),
+          timer_ref: reference() | nil
+        }
+
+  @spec start_link(Config.t() | map() | keyword(), keyword()) :: GenServer.on_start()
+  def start_link(config, opts \\ []) do
+    GenServer.start_link(__MODULE__, config, opts)
+  end
+
+  @spec is_enabled(GenServer.server(), String.t(), Context.t() | map() | nil) :: boolean()
+  def is_enabled(client, name, context \\ nil) do
+    GenServer.call(client, {:is_enabled, name, context})
+  end
+
+  @spec all_flags(GenServer.server()) :: %{optional(String.t()) => boolean()}
+  def all_flags(client), do: GenServer.call(client, :all_flags)
+
+  @spec load_flags(GenServer.server(), map()) :: :ok
+  def load_flags(client, response), do: GenServer.call(client, {:load_flags, response})
+
+  @spec close(GenServer.server()) :: :ok
+  def close(client) do
+    GenServer.stop(client, :normal)
+  end
+
+  @impl true
+  def init(raw_config) do
+    with {:ok, config} <- Config.new(raw_config),
+         {:ok, flags_by_name} <- HTTPFlagsRepository.fetch_flags(config) do
+      state = %{config: config, flags_by_name: flags_by_name, timer_ref: nil}
+      {:ok, schedule_poll(state)}
+    else
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_call({:is_enabled, name, context}, _from, state) do
+    flag = Map.get(state.flags_by_name, name)
+    enabled = Evaluator.is_flag_enabled(flag, Context.normalize(context))
+    {:reply, enabled, state}
+  end
+
+  def handle_call(:all_flags, _from, state) do
+    flags =
+      state.flags_by_name
+      |> Enum.reduce(%{}, fn {name, flag}, acc ->
+        Map.put(acc, name, flag.enabled == true)
+      end)
+
+    {:reply, flags, state}
+  end
+
+  def handle_call({:load_flags, response}, _from, state) do
+    flags_by_name = Bandeira.FlagModels.parse_response(response)
+    {:reply, :ok, %{state | flags_by_name: flags_by_name}}
+  end
+
+  @impl true
+  def handle_info(:poll, state) do
+    flags_by_name =
+      case HTTPFlagsRepository.fetch_flags(state.config) do
+        {:ok, flags} -> flags
+        {:error, _reason} -> state.flags_by_name
+      end
+
+    new_state = %{state | flags_by_name: flags_by_name, timer_ref: nil}
+    {:noreply, schedule_poll(new_state)}
+  end
+
+  defp schedule_poll(state) do
+    poll_interval = state.config.poll_interval
+    ref = Process.send_after(self(), :poll, poll_interval)
+    %{state | timer_ref: ref}
+  end
+end

--- a/elixir/lib/bandeira/config.ex
+++ b/elixir/lib/bandeira/config.ex
@@ -1,0 +1,67 @@
+defmodule Bandeira.Config do
+  @moduledoc "Configuration for a Bandeira client."
+
+  @type http_client_fun :: (String.t(), [{String.t(), String.t()}] -> {:ok, non_neg_integer(), binary()} | {:error, term()})
+
+  @type t :: %__MODULE__{
+          url: String.t(),
+          token: String.t(),
+          poll_interval: pos_integer(),
+          http_client: http_client_fun() | nil
+        }
+
+  defstruct url: "",
+            token: "",
+            poll_interval: 15_000,
+            http_client: nil
+
+  @spec new(t() | map() | keyword()) :: {:ok, t()} | {:error, String.t()}
+  def new(%__MODULE__{} = cfg), do: validate(cfg)
+
+  def new(opts) when is_list(opts) do
+    opts
+    |> Enum.into(%{})
+    |> new()
+  end
+
+  def new(map) when is_map(map) do
+    cfg = %__MODULE__{
+      url: get(map, :url, ""),
+      token: get(map, :token, ""),
+      poll_interval: get(map, :poll_interval, 15_000),
+      http_client: get(map, :http_client, nil)
+    }
+
+    validate(cfg)
+  end
+
+  def new(_), do: {:error, "bandeira: config must be a map, keyword list, or %Bandeira.Config{}"}
+
+  @spec validate(t()) :: {:ok, t()} | {:error, String.t()}
+  def validate(%__MODULE__{} = cfg) do
+    cond do
+      String.trim(to_string(cfg.url)) == "" ->
+        {:error, "bandeira: url is required"}
+
+      String.trim(to_string(cfg.token)) == "" ->
+        {:error, "bandeira: token is required"}
+
+      not is_integer(cfg.poll_interval) or cfg.poll_interval <= 0 ->
+        {:error, "bandeira: poll_interval must be a positive integer in milliseconds"}
+
+      not is_nil(cfg.http_client) and not is_function(cfg.http_client, 2) ->
+        {:error, "bandeira: http_client must be a function of arity 2"}
+
+      true ->
+        {:ok, %{cfg | url: String.trim(cfg.url), token: String.trim(cfg.token)}}
+    end
+  end
+
+  defp get(map, key, default) do
+    cond do
+      Map.has_key?(map, key) -> Map.get(map, key)
+      is_atom(key) and Map.has_key?(map, Atom.to_string(key)) -> Map.get(map, Atom.to_string(key))
+      true -> default
+    end
+  end
+end

--- a/elixir/lib/bandeira/context.ex
+++ b/elixir/lib/bandeira/context.ex
@@ -1,0 +1,50 @@
+defmodule Bandeira.Context do
+  @moduledoc "Runtime context used for strategy evaluation."
+
+  @type t :: %__MODULE__{
+          user_id: String.t(),
+          session_id: String.t(),
+          remote_address: String.t(),
+          properties: %{optional(String.t()) => String.t()}
+        }
+
+  defstruct user_id: "",
+            session_id: "",
+            remote_address: "",
+            properties: %{}
+
+  @spec normalize(t() | map() | nil) :: t()
+  def normalize(%__MODULE__{} = context), do: context
+  def normalize(nil), do: %__MODULE__{}
+
+  def normalize(map) when is_map(map) do
+    %__MODULE__{
+      user_id: get(map, :user_id, get(map, :userId, "")) |> to_string_safe(),
+      session_id: get(map, :session_id, get(map, :sessionId, "")) |> to_string_safe(),
+      remote_address: get(map, :remote_address, get(map, :remoteAddress, "")) |> to_string_safe(),
+      properties: normalize_properties(get(map, :properties, %{}))
+    }
+  end
+
+  def normalize(_), do: %__MODULE__{}
+
+  defp normalize_properties(props) when is_map(props) do
+    props
+    |> Enum.reduce(%{}, fn {key, value}, acc ->
+      Map.put(acc, to_string(key), to_string_safe(value))
+    end)
+  end
+
+  defp normalize_properties(_), do: %{}
+
+  defp to_string_safe(nil), do: ""
+  defp to_string_safe(value), do: to_string(value)
+
+  defp get(map, key, default) do
+    cond do
+      Map.has_key?(map, key) -> Map.get(map, key)
+      is_atom(key) and Map.has_key?(map, Atom.to_string(key)) -> Map.get(map, Atom.to_string(key))
+      true -> default
+    end
+  end
+end

--- a/elixir/lib/bandeira/evaluator.ex
+++ b/elixir/lib/bandeira/evaluator.ex
@@ -1,0 +1,244 @@
+defmodule Bandeira.Evaluator do
+  @moduledoc false
+
+  import Bitwise
+
+  alias Bandeira.Context
+  alias Bandeira.FlagModels.{Constraint, Flag, Strategy}
+
+  @spec is_flag_enabled(Flag.t() | nil, Context.t() | map() | nil) :: boolean()
+  def is_flag_enabled(nil, _), do: false
+
+  def is_flag_enabled(%Flag{enabled: false}, _), do: false
+
+  def is_flag_enabled(%Flag{enabled: true, strategies: []}, _), do: true
+
+  def is_flag_enabled(%Flag{} = flag, context) do
+    eval_context = Context.normalize(context)
+
+    Enum.any?(flag.strategies, fn strategy ->
+      evaluate_strategy(strategy, eval_context)
+    end)
+  end
+
+  @spec evaluate_strategy(Strategy.t(), Context.t()) :: boolean()
+  def evaluate_strategy(%Strategy{} = strategy, %Context{} = context) do
+    constraints_pass = Enum.all?(strategy.constraints, &evaluate_constraint(&1, context))
+
+    if constraints_pass do
+      case strategy.name do
+        "default" -> true
+        "userWithId" -> eval_user_with_id(strategy, context)
+        "gradualRollout" -> eval_gradual_rollout(strategy, context)
+        "remoteAddress" -> eval_remote_address(strategy, context)
+        _ -> true
+      end
+    else
+      false
+    end
+  end
+
+  @spec evaluate_constraint(Constraint.t(), Context.t()) :: boolean()
+  def evaluate_constraint(%Constraint{} = constraint, %Context{} = context) do
+    context_value = context_value(constraint.context_name, context)
+
+    result =
+      eval_operator(
+        constraint.operator,
+        context_value,
+        constraint.values,
+        constraint.case_insensitive
+      )
+
+    if constraint.inverted, do: not result, else: result
+  end
+
+  @spec split_multi(String.t()) :: [String.t()]
+  def split_multi(value) when is_binary(value) do
+    value
+    |> String.replace("\r\n", ",")
+    |> String.replace("\n", ",")
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  def split_multi(_), do: []
+
+  @spec normalized_hash(String.t()) :: non_neg_integer()
+  def normalized_hash(value) when is_binary(value) do
+    value
+    |> :unicode.characters_to_binary()
+    |> :binary.bin_to_list()
+    |> Enum.reduce(0x811C9DC5, fn byte, hash ->
+      ((hash ^^^ byte) * 0x01000193) &&& 0xFFFFFFFF
+    end)
+    |> rem(100)
+  end
+
+  def normalized_hash(_), do: 0
+
+  defp eval_user_with_id(%Strategy{} = strategy, %Context{} = context) do
+    case get(strategy.parameters, "userIds") do
+      user_ids when is_binary(user_ids) -> context.user_id in split_multi(user_ids)
+      _ -> false
+    end
+  end
+
+  defp eval_gradual_rollout(%Strategy{} = strategy, %Context{} = context) do
+    with {:ok, rollout} <- parse_rollout(get(strategy.parameters, "rollout")) do
+      cond do
+        rollout >= 100 -> true
+        rollout <= 0 -> false
+        true ->
+          stickiness = get(strategy.parameters, "stickiness")
+
+          stickiness_key =
+            if is_binary(stickiness) and stickiness != "" do
+              stickiness
+            else
+              "userId"
+            end
+
+          stickiness_value =
+            case stickiness_key do
+              "userId" -> context.user_id
+              "sessionId" -> context.session_id
+              custom -> Map.get(context.properties, custom, "")
+            end
+
+          if stickiness_value == "" do
+            false
+          else
+            group_id = get(strategy.parameters, "groupId")
+            group_id_value = if is_binary(group_id), do: group_id, else: ""
+            normalized_hash(stickiness_value <> group_id_value) < rollout
+          end
+      end
+    else
+      _ -> false
+    end
+  end
+
+  defp eval_remote_address(%Strategy{} = strategy, %Context{} = context) do
+    raw_ips =
+      case get(strategy.parameters, "ips") do
+        value when is_binary(value) -> value
+        _ -> get(strategy.parameters, "IPs")
+      end
+
+    if is_binary(raw_ips) do
+      address = context.remote_address
+
+      Enum.any?(split_multi(raw_ips), fn entry ->
+        entry == address or (String.ends_with?(entry, ".") and String.starts_with?(address, entry))
+      end)
+    else
+      false
+    end
+  end
+
+  defp context_value("userId", %Context{} = context), do: context.user_id
+  defp context_value("sessionId", %Context{} = context), do: context.session_id
+  defp context_value("remoteAddress", %Context{} = context), do: context.remote_address
+  defp context_value(name, %Context{} = context), do: Map.get(context.properties, name, "")
+
+  defp eval_operator(operator, context_value, values, case_insensitive) do
+    cv = normalize(context_value, case_insensitive)
+
+    case operator do
+      "IN" -> Enum.any?(values, &(cv == normalize(&1, case_insensitive)))
+      "NOT_IN" -> Enum.all?(values, &(cv != normalize(&1, case_insensitive)))
+      "STR_CONTAINS" -> Enum.any?(values, &String.contains?(cv, normalize(&1, case_insensitive)))
+      "STR_STARTS_WITH" -> Enum.any?(values, &String.starts_with?(cv, normalize(&1, case_insensitive)))
+      "STR_ENDS_WITH" -> Enum.any?(values, &String.ends_with?(cv, normalize(&1, case_insensitive)))
+      "NUM_EQ" -> compare_numeric(cv, values, &Kernel.==/2)
+      "NUM_GT" -> compare_numeric(cv, values, &Kernel.>/2)
+      "NUM_GTE" -> compare_numeric(cv, values, &Kernel.>=/2)
+      "NUM_LT" -> compare_numeric(cv, values, &Kernel.</2)
+      "NUM_LTE" -> compare_numeric(cv, values, &Kernel.<=/2)
+      "DATE_AFTER" -> compare_datetime(cv, values, fn value, target -> DateTime.compare(value, target) == :gt end)
+      "DATE_BEFORE" -> compare_datetime(cv, values, fn value, target -> DateTime.compare(value, target) == :lt end)
+      _ -> false
+    end
+  end
+
+  defp compare_numeric(cv, values, comparator) do
+    with {:ok, value} <- parse_float(cv) do
+      Enum.any?(values, fn raw_target ->
+        case parse_float(raw_target) do
+          {:ok, target} -> comparator.(value, target)
+          _ -> false
+        end
+      end)
+    else
+      _ -> false
+    end
+  end
+
+  defp compare_datetime(cv, values, comparator) do
+    with {:ok, value} <- parse_datetime(cv) do
+      Enum.any?(values, fn raw_target ->
+        case parse_datetime(raw_target) do
+          {:ok, target} -> comparator.(value, target)
+          _ -> false
+        end
+      end)
+    else
+      _ -> false
+    end
+  end
+
+  defp parse_rollout(raw) when is_integer(raw), do: {:ok, raw}
+  defp parse_rollout(raw) when is_float(raw), do: {:ok, trunc(raw)}
+
+  defp parse_rollout(raw) when is_binary(raw) do
+    case Integer.parse(raw) do
+      {rollout, ""} -> {:ok, rollout}
+      _ -> :error
+    end
+  end
+
+  defp parse_rollout(_), do: :error
+
+  defp parse_float(value) when is_number(value), do: {:ok, value * 1.0}
+
+  defp parse_float(value) when is_binary(value) do
+    case Float.parse(value) do
+      {number, ""} -> {:ok, number}
+      _ -> :error
+    end
+  end
+
+  defp parse_float(_), do: :error
+
+  defp parse_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> {:ok, datetime}
+      _ -> :error
+    end
+  end
+
+  defp parse_datetime(_), do: :error
+
+  defp normalize(value, true), do: value |> to_string() |> String.downcase()
+  defp normalize(value, false), do: to_string(value)
+
+  defp get(parameters, key) when is_map(parameters) do
+    cond do
+      Map.has_key?(parameters, key) -> Map.get(parameters, key)
+      is_binary(key) ->
+        Enum.find_value(parameters, fn
+          {atom_key, value} when is_atom(atom_key) ->
+            if Atom.to_string(atom_key) == key, do: value, else: nil
+
+          _ ->
+            nil
+        end)
+
+      true -> nil
+    end
+  end
+
+  defp get(_parameters, _key), do: nil
+end

--- a/elixir/lib/bandeira/flag_models.ex
+++ b/elixir/lib/bandeira/flag_models.ex
@@ -1,0 +1,125 @@
+defmodule Bandeira.FlagModels do
+  @moduledoc false
+
+  defmodule Flag do
+    @moduledoc false
+    defstruct name: "", enabled: false, strategies: []
+
+    @type t :: %__MODULE__{
+            name: String.t(),
+            enabled: boolean(),
+            strategies: [Bandeira.FlagModels.Strategy.t()]
+          }
+  end
+
+  defmodule Strategy do
+    @moduledoc false
+    defstruct name: "", parameters: %{}, constraints: []
+
+    @type t :: %__MODULE__{
+            name: String.t(),
+            parameters: map(),
+            constraints: [Bandeira.FlagModels.Constraint.t()]
+          }
+  end
+
+  defmodule Constraint do
+    @moduledoc false
+    defstruct context_name: "", operator: "", values: [], inverted: false, case_insensitive: false
+
+    @type t :: %__MODULE__{
+            context_name: String.t(),
+            operator: String.t(),
+            values: [String.t()],
+            inverted: boolean(),
+            case_insensitive: boolean()
+          }
+  end
+
+  alias __MODULE__.{Constraint, Flag, Strategy}
+
+  @spec parse_response(map()) :: %{optional(String.t()) => Flag.t()}
+  def parse_response(data) when is_map(data) do
+    data
+    |> get(:flags, [])
+    |> case do
+      flags when is_list(flags) ->
+        Enum.reduce(flags, %{}, fn raw, acc ->
+          flag = to_flag(raw)
+
+          if flag.name == "" do
+            acc
+          else
+            Map.put(acc, flag.name, flag)
+          end
+        end)
+
+      _ ->
+        %{}
+    end
+  end
+
+  def parse_response(_), do: %{}
+
+  @spec to_flag(map()) :: Flag.t()
+  def to_flag(raw) when is_map(raw) do
+    %Flag{
+      name: get(raw, :name, "") |> to_string_safe(),
+      enabled: get(raw, :enabled, false) == true,
+      strategies: to_strategies(get(raw, :strategies, []))
+    }
+  end
+
+  def to_flag(_), do: %Flag{}
+
+  defp to_strategies(strategies) when is_list(strategies) do
+    Enum.map(strategies, &to_strategy/1)
+  end
+
+  defp to_strategies(_), do: []
+
+  defp to_strategy(raw) when is_map(raw) do
+    %Strategy{
+      name: get(raw, :name, "") |> to_string_safe(),
+      parameters: to_parameters(get(raw, :parameters, %{})),
+      constraints: to_constraints(get(raw, :constraints, []))
+    }
+  end
+
+  defp to_strategy(_), do: %Strategy{}
+
+  defp to_parameters(parameters) when is_map(parameters), do: parameters
+  defp to_parameters(_), do: %{}
+
+  defp to_constraints(constraints) when is_list(constraints) do
+    Enum.map(constraints, &to_constraint/1)
+  end
+
+  defp to_constraints(_), do: []
+
+  defp to_constraint(raw) when is_map(raw) do
+    %Constraint{
+      context_name: get(raw, :context_name, "") |> to_string_safe(),
+      operator: get(raw, :operator, "") |> to_string_safe(),
+      values: to_values(get(raw, :values, [])),
+      inverted: get(raw, :inverted, false) == true,
+      case_insensitive: get(raw, :case_insensitive, false) == true
+    }
+  end
+
+  defp to_constraint(_), do: %Constraint{}
+
+  defp to_values(values) when is_list(values), do: Enum.map(values, &to_string_safe/1)
+  defp to_values(_), do: []
+
+  defp get(map, key, default) do
+    cond do
+      Map.has_key?(map, key) -> Map.get(map, key)
+      is_atom(key) and Map.has_key?(map, Atom.to_string(key)) -> Map.get(map, Atom.to_string(key))
+      true -> default
+    end
+  end
+
+  defp to_string_safe(nil), do: ""
+  defp to_string_safe(value), do: to_string(value)
+end

--- a/elixir/lib/bandeira/http_flags_repository.ex
+++ b/elixir/lib/bandeira/http_flags_repository.ex
@@ -1,0 +1,67 @@
+defmodule Bandeira.HTTPFlagsRepository do
+  @moduledoc false
+
+  alias Bandeira.Config
+  alias Bandeira.FlagModels
+
+  @spec fetch_flags(Config.t()) :: {:ok, %{optional(String.t()) => Bandeira.FlagModels.Flag.t()}} | {:error, String.t()}
+  def fetch_flags(%Config{} = config) do
+    url = normalized_url(config.url) <> "/api/v1/flags"
+    headers = [{"authorization", "Bearer " <> config.token}]
+
+    with {:ok, status, body} <- request(config, url, headers),
+         :ok <- ensure_ok(status, body),
+         {:ok, decoded} <- decode_json(body) do
+      {:ok, FlagModels.parse_response(decoded)}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp request(%Config{http_client: fun}, url, headers) when is_function(fun, 2) do
+    fun.(url, headers)
+  rescue
+    error -> {:error, "request failed: #{Exception.message(error)}"}
+  end
+
+  defp request(_config, url, headers), do: default_http_get(url, headers)
+
+  @doc false
+  @spec default_http_get(String.t(), [{String.t(), String.t()}]) :: {:ok, non_neg_integer(), binary()} | {:error, String.t()}
+  def default_http_get(url, headers) do
+    _ = :inets.start()
+    _ = :ssl.start()
+
+    req_headers =
+      Enum.map(headers, fn {name, value} ->
+        {String.to_charlist(name), String.to_charlist(value)}
+      end)
+
+    request = {String.to_charlist(url), req_headers}
+
+    case :httpc.request(:get, request, [timeout: 10_000], body_format: :binary) do
+      {:ok, {{_http_version, status, _reason}, _resp_headers, body}} ->
+        {:ok, status, IO.iodata_to_binary(body)}
+
+      {:error, reason} ->
+        {:error, "request failed: #{inspect(reason)}"}
+    end
+  end
+
+  defp ensure_ok(200, _body), do: :ok
+
+  defp ensure_ok(status, body) do
+    {:error, "unexpected status #{status}: #{body}"}
+  end
+
+  defp decode_json(body) do
+    case Jason.decode(body) do
+      {:ok, data} -> {:ok, data}
+      {:error, error} -> {:error, "failed to decode response: #{Exception.message(error)}"}
+    end
+  end
+
+  defp normalized_url(url) do
+    String.replace(to_string(url), ~r{/+$}, "")
+  end
+end

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -1,0 +1,36 @@
+defmodule Bandeira.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :bandeira,
+      version: "0.1.0",
+      elixir: "~> 1.16",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      description: "Official Elixir client SDK for Bandeira feature flag service",
+      package: package()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger, :inets, :ssl]
+    ]
+  end
+
+  defp deps do
+    [
+      {:jason, "~> 1.4"}
+    ]
+  end
+
+  defp package do
+    [
+      licenses: ["MIT"],
+      links: %{
+        "GitHub" => "https://github.com/felipekafuri/bandeira-sdks"
+      }
+    ]
+  end
+end

--- a/elixir/test/bandeira/client_test.exs
+++ b/elixir/test/bandeira/client_test.exs
@@ -1,0 +1,130 @@
+defmodule Bandeira.ClientTest do
+  use ExUnit.Case
+
+  alias Bandeira.Client
+  alias Bandeira.Config
+  alias Bandeira.Context
+
+  import Bandeira.TestFixtures
+
+  test "start_link performs initial fetch and includes authorization header" do
+    test_pid = self()
+    payload = Jason.encode!(fixture_payload())
+
+    http_fun = fn url, headers ->
+      send(test_pid, {:request, url, headers})
+      {:ok, 200, payload}
+    end
+
+    config = %Config{
+      url: "http://localhost:9999/",
+      token: "test-token",
+      poll_interval: 60_000,
+      http_client: http_fun
+    }
+
+    {:ok, pid} = Client.start_link(config)
+    on_exit(fn -> Client.close(pid) end)
+
+    assert_receive {:request, "http://localhost:9999/api/v1/flags", headers}
+    assert {"authorization", "Bearer test-token"} in headers
+    assert Client.is_enabled(pid, "simple-on", %Context{})
+  end
+
+  test "start_link fails fast when initial request is unauthorized" do
+    config = %Config{
+      url: "http://localhost:9999",
+      token: "bad-token",
+      poll_interval: 60_000,
+      http_client: fn _url, _headers -> {:ok, 401, "unauthorized"} end
+    }
+
+    assert {:error, reason} = Client.start_link(config)
+    assert to_string(reason) =~ "unexpected status 401"
+  end
+
+  test "all_flags returns enabled snapshot" do
+    payload = Jason.encode!(fixture_payload())
+
+    config = %Config{
+      url: "http://localhost:9999",
+      token: "test-token",
+      poll_interval: 60_000,
+      http_client: fn _url, _headers -> {:ok, 200, payload} end
+    }
+
+    {:ok, pid} = Client.start_link(config)
+    on_exit(fn -> Client.close(pid) end)
+
+    flags = Client.all_flags(pid)
+    assert flags["simple-on"] == true
+    assert flags["simple-off"] == false
+  end
+
+  test "load_flags allows direct fixture injection" do
+    payload = Jason.encode!(%{"flags" => []})
+
+    config = %Config{
+      url: "http://localhost:9999",
+      token: "test-token",
+      poll_interval: 60_000,
+      http_client: fn _url, _headers -> {:ok, 200, payload} end
+    }
+
+    {:ok, pid} = Client.start_link(config)
+    on_exit(fn -> Client.close(pid) end)
+
+    response = %{
+      "flags" => [
+        %{"name" => "manual-flag", "enabled" => true, "strategies" => []}
+      ]
+    }
+
+    assert :ok == Client.load_flags(pid, response)
+    assert Client.is_enabled(pid, "manual-flag", nil)
+  end
+
+  test "polling keeps last known cache on failures" do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+    payload = Jason.encode!(fixture_payload())
+
+    http_fun = fn _url, _headers ->
+      attempt =
+        Agent.get_and_update(counter, fn current ->
+          {current, current + 1}
+        end)
+
+      if attempt == 0 do
+        {:ok, 200, payload}
+      else
+        {:ok, 500, "temporary failure"}
+      end
+    end
+
+    config = %Config{
+      url: "http://localhost:9999",
+      token: "test-token",
+      poll_interval: 5,
+      http_client: http_fun
+    }
+
+    {:ok, pid} = Client.start_link(config)
+
+    on_exit(fn ->
+      Client.close(pid)
+      Agent.stop(counter)
+    end)
+
+    assert Client.is_enabled(pid, "simple-on", nil)
+    Process.sleep(30)
+    assert Client.is_enabled(pid, "simple-on", nil)
+  end
+
+  test "validation errors for missing url and token" do
+    assert {:error, reason1} = Client.start_link(%Config{url: "", token: "x"})
+    assert to_string(reason1) =~ "url is required"
+
+    assert {:error, reason2} = Client.start_link(%Config{url: "http://localhost", token: ""})
+    assert to_string(reason2) =~ "token is required"
+  end
+end

--- a/elixir/test/bandeira/evaluator_test.exs
+++ b/elixir/test/bandeira/evaluator_test.exs
@@ -1,0 +1,167 @@
+defmodule Bandeira.EvaluatorTest do
+  use ExUnit.Case, async: true
+
+  alias Bandeira.Context
+  alias Bandeira.Evaluator
+  alias Bandeira.FlagModels.{Constraint, Flag, Strategy}
+
+  import Bandeira.TestFixtures
+
+  test "enabled flag with no strategies returns true" do
+    assert Evaluator.is_flag_enabled(flag!("simple-on"), nil)
+  end
+
+  test "disabled flag returns false" do
+    refute Evaluator.is_flag_enabled(flag!("simple-off"), nil)
+  end
+
+  test "default strategy returns true" do
+    assert Evaluator.is_flag_enabled(flag!("default-strategy"), nil)
+  end
+
+  test "userWithId matches listed user" do
+    context = %Context{user_id: "user-42"}
+    assert Evaluator.is_flag_enabled(flag!("user-targeting"), context)
+  end
+
+  test "userWithId rejects unlisted user" do
+    context = %Context{user_id: "user-99"}
+    refute Evaluator.is_flag_enabled(flag!("user-targeting"), context)
+  end
+
+  test "userWithId rejects without context" do
+    refute Evaluator.is_flag_enabled(flag!("user-targeting"), nil)
+  end
+
+  test "userWithId handles newline-separated user IDs" do
+    assert Evaluator.is_flag_enabled(flag!("user-targeting-newlines"), %Context{user_id: "user-42"})
+    refute Evaluator.is_flag_enabled(flag!("user-targeting-newlines"), %Context{user_id: "user-99"})
+  end
+
+  test "gradualRollout 100 percent is always on" do
+    assert Evaluator.is_flag_enabled(flag!("rollout-100"), %Context{user_id: "anyone"})
+  end
+
+  test "gradualRollout 0 percent is always off" do
+    refute Evaluator.is_flag_enabled(flag!("rollout-0"), %Context{user_id: "anyone"})
+  end
+
+  test "gradualRollout with missing stickiness returns false" do
+    refute Evaluator.is_flag_enabled(flag!("rollout-50"), nil)
+  end
+
+  test "gradualRollout session stickiness returns a boolean" do
+    result = Evaluator.is_flag_enabled(flag!("rollout-session-stickiness"), %Context{session_id: "sess-123"})
+    assert is_boolean(result)
+  end
+
+  test "remoteAddress exact match" do
+    assert Evaluator.is_flag_enabled(flag!("ip-allowlist"), %Context{remote_address: "10.0.0.1"})
+  end
+
+  test "remoteAddress prefix match" do
+    assert Evaluator.is_flag_enabled(flag!("ip-allowlist"), %Context{remote_address: "192.168.1.100"})
+  end
+
+  test "remoteAddress no match" do
+    refute Evaluator.is_flag_enabled(flag!("ip-allowlist"), %Context{remote_address: "172.16.0.1"})
+  end
+
+  test "remoteAddress supports legacy IPs parameter key" do
+    assert Evaluator.is_flag_enabled(flag!("ip-allowlist-legacy"), %Context{remote_address: "10.0.0.1"})
+  end
+
+  test "constraint IN matches" do
+    context = %Context{properties: %{"companyId" => "2"}}
+    assert Evaluator.is_flag_enabled(flag!("constraint-in"), context)
+  end
+
+  test "constraint IN rejects" do
+    context = %Context{properties: %{"companyId" => "99"}}
+    refute Evaluator.is_flag_enabled(flag!("constraint-in"), context)
+  end
+
+  test "constraint NOT_IN matches" do
+    context = %Context{properties: %{"plan" => "enterprise"}}
+    assert Evaluator.is_flag_enabled(flag!("constraint-not-in"), context)
+  end
+
+  test "constraint NOT_IN rejects" do
+    context = %Context{properties: %{"plan" => "free"}}
+    refute Evaluator.is_flag_enabled(flag!("constraint-not-in"), context)
+  end
+
+  test "inverted constraint" do
+    free = %Context{properties: %{"plan" => "free"}}
+    enterprise = %Context{properties: %{"plan" => "enterprise"}}
+
+    refute Evaluator.is_flag_enabled(flag!("constraint-inverted"), free)
+    assert Evaluator.is_flag_enabled(flag!("constraint-inverted"), enterprise)
+  end
+
+  test "case-insensitive constraint" do
+    assert Evaluator.is_flag_enabled(flag!("constraint-case-insensitive"), %Context{properties: %{"country" => "brazil"}})
+    assert Evaluator.is_flag_enabled(flag!("constraint-case-insensitive"), %Context{properties: %{"country" => "PORTUGAL"}})
+    refute Evaluator.is_flag_enabled(flag!("constraint-case-insensitive"), %Context{properties: %{"country" => "spain"}})
+  end
+
+  test "STR_CONTAINS constraint" do
+    assert Evaluator.is_flag_enabled(flag!("constraint-str-contains"), %Context{properties: %{"email" => "user@acme.com"}})
+    refute Evaluator.is_flag_enabled(flag!("constraint-str-contains"), %Context{properties: %{"email" => "user@other.com"}})
+  end
+
+  test "STR_STARTS_WITH constraint" do
+    assert Evaluator.is_flag_enabled(flag!("constraint-str-starts-with"), %Context{properties: %{"email" => "admin@acme.com"}})
+    refute Evaluator.is_flag_enabled(flag!("constraint-str-starts-with"), %Context{properties: %{"email" => "user@acme.com"}})
+  end
+
+  test "STR_ENDS_WITH constraint" do
+    assert Evaluator.is_flag_enabled(flag!("constraint-str-ends-with"), %Context{properties: %{"email" => "user@acme.com"}})
+    refute Evaluator.is_flag_enabled(flag!("constraint-str-ends-with"), %Context{properties: %{"email" => "user@acme.io"}})
+  end
+
+  test "NUM_GTE constraint" do
+    assert Evaluator.is_flag_enabled(flag!("constraint-num-gte"), %Context{properties: %{"age" => "21"}})
+    assert Evaluator.is_flag_enabled(flag!("constraint-num-gte"), %Context{properties: %{"age" => "18"}})
+    refute Evaluator.is_flag_enabled(flag!("constraint-num-gte"), %Context{properties: %{"age" => "16"}})
+  end
+
+  test "DATE_AFTER constraint" do
+    assert Evaluator.is_flag_enabled(flag!("constraint-date-after"), %Context{properties: %{"signupDate" => "2026-06-15T00:00:00Z"}})
+    refute Evaluator.is_flag_enabled(flag!("constraint-date-after"), %Context{properties: %{"signupDate" => "2025-06-15T00:00:00Z"}})
+  end
+
+  test "multi-strategy uses OR logic" do
+    assert Evaluator.is_flag_enabled(flag!("multi-strategy"), %Context{user_id: "vip-1"})
+  end
+
+  test "constrained rollout passes when constraint matches" do
+    context = %Context{user_id: "any-user", properties: %{"companyId" => "acme"}}
+    assert Evaluator.is_flag_enabled(flag!("constrained-rollout"), context)
+  end
+
+  test "constrained rollout fails when constraint does not match" do
+    context = %Context{user_id: "any-user", properties: %{"companyId" => "other"}}
+    refute Evaluator.is_flag_enabled(flag!("constrained-rollout"), context)
+  end
+
+  test "unknown strategy fails open" do
+    flag = %Flag{name: "unknown", enabled: true, strategies: [%Strategy{name: "someFutureStrategy"}]}
+    assert Evaluator.is_flag_enabled(flag, %Context{})
+  end
+
+  test "unknown operator returns false" do
+    flag = %Flag{
+      name: "unknown-op",
+      enabled: true,
+      strategies: [
+        %Strategy{
+          name: "default",
+          constraints: [%Constraint{context_name: "region", operator: "UNKNOWN", values: ["us"]}]
+        }
+      ]
+    }
+
+    refute Evaluator.is_flag_enabled(flag, %Context{properties: %{"region" => "us"}})
+  end
+end

--- a/elixir/test/support/fixtures.ex
+++ b/elixir/test/support/fixtures.ex
@@ -1,0 +1,23 @@
+defmodule Bandeira.TestFixtures do
+  @moduledoc false
+
+  alias Bandeira.FlagModels
+
+  @fixtures_path Path.expand("../../../testdata/flags.json", __DIR__)
+
+  def fixture_payload do
+    @fixtures_path
+    |> File.read!()
+    |> Jason.decode!()
+  end
+
+  def flags_by_name do
+    fixture_payload()
+    |> FlagModels.parse_response()
+  end
+
+  def flag!(name) do
+    flags_by_name()
+    |> Map.fetch!(name)
+  end
+end

--- a/elixir/test/test_helper.exs
+++ b/elixir/test/test_helper.exs
@@ -1,0 +1,2 @@
+ExUnit.start()
+Code.require_file("support/fixtures.ex", __DIR__)


### PR DESCRIPTION
## Summary
- Add Dart/Flutter SDK with full strategy evaluation and constraint support
- Add Elixir SDK with GenServer-based polling client
- Update README with install commands and quick start examples
- Update .gitignore for Dart and Elixir build artifacts

Cherry-picked from PRs #2 and #4 with merge conflicts resolved.

Closes #2
Closes #4