### PR TITLE
Fix Elixir formatting

### DIFF
--- a/elixir/lib/bandeira/config.ex
+++ b/elixir/lib/bandeira/config.ex
@@ -1,7 +1,8 @@
 defmodule Bandeira.Config do
   @moduledoc "Configuration for a Bandeira client."
 
-  @type http_client_fun :: (String.t(), [{String.t(), String.t()}] -> {:ok, non_neg_integer(), binary()} | {:error, term()})
+  @type http_client_fun :: (String.t(), [{String.t(), String.t()}] ->
+                              {:ok, non_neg_integer(), binary()} | {:error, term()})
 
   @type t :: %__MODULE__{
           url: String.t(),

--- a/elixir/lib/bandeira/evaluator.ex
+++ b/elixir/lib/bandeira/evaluator.ex
@@ -71,7 +71,7 @@ defmodule Bandeira.Evaluator do
     |> :unicode.characters_to_binary()
     |> :binary.bin_to_list()
     |> Enum.reduce(0x811C9DC5, fn byte, hash ->
-      ((hash ^^^ byte) * 0x01000193) &&& 0xFFFFFFFF
+      (hash ^^^ byte) * 0x01000193 &&& 0xFFFFFFFF
     end)
     |> rem(100)
   end
@@ -88,8 +88,12 @@ defmodule Bandeira.Evaluator do
   defp eval_gradual_rollout(%Strategy{} = strategy, %Context{} = context) do
     with {:ok, rollout} <- parse_rollout(get(strategy.parameters, "rollout")) do
       cond do
-        rollout >= 100 -> true
-        rollout <= 0 -> false
+        rollout >= 100 ->
+          true
+
+        rollout <= 0 ->
+          false
+
         true ->
           stickiness = get(strategy.parameters, "stickiness")
 
@@ -131,7 +135,8 @@ defmodule Bandeira.Evaluator do
       address = context.remote_address
 
       Enum.any?(split_multi(raw_ips), fn entry ->
-        entry == address or (String.ends_with?(entry, ".") and String.starts_with?(address, entry))
+        entry == address or
+          (String.ends_with?(entry, ".") and String.starts_with?(address, entry))
       end)
     else
       false
@@ -147,19 +152,48 @@ defmodule Bandeira.Evaluator do
     cv = normalize(context_value, case_insensitive)
 
     case operator do
-      "IN" -> Enum.any?(values, &(cv == normalize(&1, case_insensitive)))
-      "NOT_IN" -> Enum.all?(values, &(cv != normalize(&1, case_insensitive)))
-      "STR_CONTAINS" -> Enum.any?(values, &String.contains?(cv, normalize(&1, case_insensitive)))
-      "STR_STARTS_WITH" -> Enum.any?(values, &String.starts_with?(cv, normalize(&1, case_insensitive)))
-      "STR_ENDS_WITH" -> Enum.any?(values, &String.ends_with?(cv, normalize(&1, case_insensitive)))
-      "NUM_EQ" -> compare_numeric(cv, values, &Kernel.==/2)
-      "NUM_GT" -> compare_numeric(cv, values, &Kernel.>/2)
-      "NUM_GTE" -> compare_numeric(cv, values, &Kernel.>=/2)
-      "NUM_LT" -> compare_numeric(cv, values, &Kernel.</2)
-      "NUM_LTE" -> compare_numeric(cv, values, &Kernel.<=/2)
-      "DATE_AFTER" -> compare_datetime(cv, values, fn value, target -> DateTime.compare(value, target) == :gt end)
-      "DATE_BEFORE" -> compare_datetime(cv, values, fn value, target -> DateTime.compare(value, target) == :lt end)
-      _ -> false
+      "IN" ->
+        Enum.any?(values, &(cv == normalize(&1, case_insensitive)))
+
+      "NOT_IN" ->
+        Enum.all?(values, &(cv != normalize(&1, case_insensitive)))
+
+      "STR_CONTAINS" ->
+        Enum.any?(values, &String.contains?(cv, normalize(&1, case_insensitive)))
+
+      "STR_STARTS_WITH" ->
+        Enum.any?(values, &String.starts_with?(cv, normalize(&1, case_insensitive)))
+
+      "STR_ENDS_WITH" ->
+        Enum.any?(values, &String.ends_with?(cv, normalize(&1, case_insensitive)))
+
+      "NUM_EQ" ->
+        compare_numeric(cv, values, &Kernel.==/2)
+
+      "NUM_GT" ->
+        compare_numeric(cv, values, &Kernel.>/2)
+
+      "NUM_GTE" ->
+        compare_numeric(cv, values, &Kernel.>=/2)
+
+      "NUM_LT" ->
+        compare_numeric(cv, values, &Kernel.</2)
+
+      "NUM_LTE" ->
+        compare_numeric(cv, values, &Kernel.<=/2)
+
+      "DATE_AFTER" ->
+        compare_datetime(cv, values, fn value, target ->
+          DateTime.compare(value, target) == :gt
+        end)
+
+      "DATE_BEFORE" ->
+        compare_datetime(cv, values, fn value, target ->
+          DateTime.compare(value, target) == :lt
+        end)
+
+      _ ->
+        false
     end
   end
 
@@ -226,7 +260,9 @@ defmodule Bandeira.Evaluator do
 
   defp get(parameters, key) when is_map(parameters) do
     cond do
-      Map.has_key?(parameters, key) -> Map.get(parameters, key)
+      Map.has_key?(parameters, key) ->
+        Map.get(parameters, key)
+
       is_binary(key) ->
         Enum.find_value(parameters, fn
           {atom_key, value} when is_atom(atom_key) ->
@@ -236,7 +272,8 @@ defmodule Bandeira.Evaluator do
             nil
         end)
 
-      true -> nil
+      true ->
+        nil
     end
   end
 

--- a/elixir/lib/bandeira/http_flags_repository.ex
+++ b/elixir/lib/bandeira/http_flags_repository.ex
@@ -4,7 +4,8 @@ defmodule Bandeira.HTTPFlagsRepository do
   alias Bandeira.Config
   alias Bandeira.FlagModels
 
-  @spec fetch_flags(Config.t()) :: {:ok, %{optional(String.t()) => Bandeira.FlagModels.Flag.t()}} | {:error, String.t()}
+  @spec fetch_flags(Config.t()) ::
+          {:ok, %{optional(String.t()) => Bandeira.FlagModels.Flag.t()}} | {:error, String.t()}
   def fetch_flags(%Config{} = config) do
     url = normalized_url(config.url) <> "/api/v1/flags"
     headers = [{"authorization", "Bearer " <> config.token}]
@@ -27,7 +28,8 @@ defmodule Bandeira.HTTPFlagsRepository do
   defp request(_config, url, headers), do: default_http_get(url, headers)
 
   @doc false
-  @spec default_http_get(String.t(), [{String.t(), String.t()}]) :: {:ok, non_neg_integer(), binary()} | {:error, String.t()}
+  @spec default_http_get(String.t(), [{String.t(), String.t()}]) ::
+          {:ok, non_neg_integer(), binary()} | {:error, String.t()}
   def default_http_get(url, headers) do
     _ = :inets.start()
     _ = :ssl.start()

--- a/elixir/test/bandeira/evaluator_test.exs
+++ b/elixir/test/bandeira/evaluator_test.exs
@@ -34,8 +34,13 @@ defmodule Bandeira.EvaluatorTest do
   end
 
   test "userWithId handles newline-separated user IDs" do
-    assert Evaluator.is_flag_enabled(flag!("user-targeting-newlines"), %Context{user_id: "user-42"})
-    refute Evaluator.is_flag_enabled(flag!("user-targeting-newlines"), %Context{user_id: "user-99"})
+    assert Evaluator.is_flag_enabled(flag!("user-targeting-newlines"), %Context{
+             user_id: "user-42"
+           })
+
+    refute Evaluator.is_flag_enabled(flag!("user-targeting-newlines"), %Context{
+             user_id: "user-99"
+           })
   end
 
   test "gradualRollout 100 percent is always on" do
@@ -51,7 +56,10 @@ defmodule Bandeira.EvaluatorTest do
   end
 
   test "gradualRollout session stickiness returns a boolean" do
-    result = Evaluator.is_flag_enabled(flag!("rollout-session-stickiness"), %Context{session_id: "sess-123"})
+    result =
+      Evaluator.is_flag_enabled(flag!("rollout-session-stickiness"), %Context{
+        session_id: "sess-123"
+      })
     assert is_boolean(result)
   end
 
@@ -60,7 +68,9 @@ defmodule Bandeira.EvaluatorTest do
   end
 
   test "remoteAddress prefix match" do
-    assert Evaluator.is_flag_enabled(flag!("ip-allowlist"), %Context{remote_address: "192.168.1.100"})
+    assert Evaluator.is_flag_enabled(flag!("ip-allowlist"), %Context{
+             remote_address: "192.168.1.100"
+           })
   end
 
   test "remoteAddress no match" do
@@ -68,7 +78,9 @@ defmodule Bandeira.EvaluatorTest do
   end
 
   test "remoteAddress supports legacy IPs parameter key" do
-    assert Evaluator.is_flag_enabled(flag!("ip-allowlist-legacy"), %Context{remote_address: "10.0.0.1"})
+    assert Evaluator.is_flag_enabled(flag!("ip-allowlist-legacy"), %Context{
+             remote_address: "10.0.0.1"
+           })
   end
 
   test "constraint IN matches" do
@@ -100,35 +112,71 @@ defmodule Bandeira.EvaluatorTest do
   end
 
   test "case-insensitive constraint" do
-    assert Evaluator.is_flag_enabled(flag!("constraint-case-insensitive"), %Context{properties: %{"country" => "brazil"}})
-    assert Evaluator.is_flag_enabled(flag!("constraint-case-insensitive"), %Context{properties: %{"country" => "PORTUGAL"}})
-    refute Evaluator.is_flag_enabled(flag!("constraint-case-insensitive"), %Context{properties: %{"country" => "spain"}})
+    assert Evaluator.is_flag_enabled(flag!("constraint-case-insensitive"), %Context{
+             properties: %{"country" => "brazil"}
+           })
+
+    assert Evaluator.is_flag_enabled(flag!("constraint-case-insensitive"), %Context{
+             properties: %{"country" => "PORTUGAL"}
+           })
+
+    refute Evaluator.is_flag_enabled(flag!("constraint-case-insensitive"), %Context{
+             properties: %{"country" => "spain"}
+           })
   end
 
   test "STR_CONTAINS constraint" do
-    assert Evaluator.is_flag_enabled(flag!("constraint-str-contains"), %Context{properties: %{"email" => "user@acme.com"}})
-    refute Evaluator.is_flag_enabled(flag!("constraint-str-contains"), %Context{properties: %{"email" => "user@other.com"}})
+    assert Evaluator.is_flag_enabled(flag!("constraint-str-contains"), %Context{
+             properties: %{"email" => "user@acme.com"}
+           })
+
+    refute Evaluator.is_flag_enabled(flag!("constraint-str-contains"), %Context{
+             properties: %{"email" => "user@other.com"}
+           })
   end
 
   test "STR_STARTS_WITH constraint" do
-    assert Evaluator.is_flag_enabled(flag!("constraint-str-starts-with"), %Context{properties: %{"email" => "admin@acme.com"}})
-    refute Evaluator.is_flag_enabled(flag!("constraint-str-starts-with"), %Context{properties: %{"email" => "user@acme.com"}})
+    assert Evaluator.is_flag_enabled(flag!("constraint-str-starts-with"), %Context{
+             properties: %{"email" => "admin@acme.com"}
+           })
+
+    refute Evaluator.is_flag_enabled(flag!("constraint-str-starts-with"), %Context{
+             properties: %{"email" => "user@acme.com"}
+           })
   end
 
   test "STR_ENDS_WITH constraint" do
-    assert Evaluator.is_flag_enabled(flag!("constraint-str-ends-with"), %Context{properties: %{"email" => "user@acme.com"}})
-    refute Evaluator.is_flag_enabled(flag!("constraint-str-ends-with"), %Context{properties: %{"email" => "user@acme.io"}})
+    assert Evaluator.is_flag_enabled(flag!("constraint-str-ends-with"), %Context{
+             properties: %{"email" => "user@acme.com"}
+           })
+
+    refute Evaluator.is_flag_enabled(flag!("constraint-str-ends-with"), %Context{
+             properties: %{"email" => "user@acme.io"}
+           })
   end
 
   test "NUM_GTE constraint" do
-    assert Evaluator.is_flag_enabled(flag!("constraint-num-gte"), %Context{properties: %{"age" => "21"}})
-    assert Evaluator.is_flag_enabled(flag!("constraint-num-gte"), %Context{properties: %{"age" => "18"}})
-    refute Evaluator.is_flag_enabled(flag!("constraint-num-gte"), %Context{properties: %{"age" => "16"}})
+    assert Evaluator.is_flag_enabled(flag!("constraint-num-gte"), %Context{
+             properties: %{"age" => "21"}
+           })
+
+    assert Evaluator.is_flag_enabled(flag!("constraint-num-gte"), %Context{
+             properties: %{"age" => "18"}
+           })
+
+    refute Evaluator.is_flag_enabled(flag!("constraint-num-gte"), %Context{
+             properties: %{"age" => "16"}
+           })
   end
 
   test "DATE_AFTER constraint" do
-    assert Evaluator.is_flag_enabled(flag!("constraint-date-after"), %Context{properties: %{"signupDate" => "2026-06-15T00:00:00Z"}})
-    refute Evaluator.is_flag_enabled(flag!("constraint-date-after"), %Context{properties: %{"signupDate" => "2025-06-15T00:00:00Z"}})
+    assert Evaluator.is_flag_enabled(flag!("constraint-date-after"), %Context{
+             properties: %{"signupDate" => "2026-06-15T00:00:00Z"}
+           })
+
+    refute Evaluator.is_flag_enabled(flag!("constraint-date-after"), %Context{
+             properties: %{"signupDate" => "2025-06-15T00:00:00Z"}
+           })
   end
 
   test "multi-strategy uses OR logic" do
@@ -146,7 +194,12 @@ defmodule Bandeira.EvaluatorTest do
   end
 
   test "unknown strategy fails open" do
-    flag = %Flag{name: "unknown", enabled: true, strategies: [%Strategy{name: "someFutureStrategy"}]}
+    flag = %Flag{
+      name: "unknown",
+      enabled: true,
+      strategies: [%Strategy{name: "someFutureStrategy"}]
+    }
+
     assert Evaluator.is_flag_enabled(flag, %Context{})
   end
 


### PR DESCRIPTION
## Summary
- Fix `mix format --check-formatted` failures in Elixir SDK
- Applied standard Elixir formatter conventions to evaluator.ex, evaluator_test.exs, http_flags_repository.ex, and config.ex

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>